### PR TITLE
Fix(token-common): serde implementation for Address uses hex encoding

### DIFF
--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -145,10 +145,11 @@ async fn test_deploy_token_factory() {
     // In reality we would deploy the locker contract and get its address,
     // but that is not needed for this test. We can choose any address we like.
     let locker_address = Address::decode("000000000000000000000000000000000000000a").unwrap();
-    let locker_id = format!("{}.{}", locker_address.encode(), engine.inner.id().as_str())
-        .parse()
-        .unwrap();
-    let _factory = crate::token_factory_utils::TokenFactory::deploy(&worker, &locker_id)
-        .await
-        .unwrap();
+    let _factory = crate::token_factory_utils::TokenFactory::deploy(
+        &worker,
+        locker_address,
+        engine.inner.id(),
+    )
+    .await
+    .unwrap();
 }

--- a/tests/src/token_factory_utils.rs
+++ b/tests/src/token_factory_utils.rs
@@ -1,3 +1,4 @@
+use aurora_engine_types::types::Address;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use workspaces::{network::Sandbox, Worker};
@@ -12,7 +13,8 @@ pub struct TokenFactory {
 impl TokenFactory {
     pub async fn deploy(
         worker: &Worker<Sandbox>,
-        locker: &workspaces::AccountId,
+        locker: Address,
+        engine: &workspaces::AccountId,
     ) -> anyhow::Result<Self> {
         // Compile and deploy factory contract
         let wasm = Self::compile_factory().await?;
@@ -28,7 +30,8 @@ impl TokenFactory {
         contract
             .call("new")
             .args_json(serde_json::json!({
-                "locker": locker,
+                "locker": locker.encode(),
+                "aurora": engine,
             }))
             .max_gas()
             .transact()


### PR DESCRIPTION
Encoding the Address type using hex makes it much easier to pass via JSON. CI is also now green again.