### PR TITLE
feat(metadata): Trustless process to set the metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ethabi = "17.2"
 hex = "0.4"
 near-contract-standards = "4.0.0"
 near-sdk = "4.0.0"
+near-token-common = { path = "near-token-common" }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.18", features = ["full"] }
@@ -42,4 +43,3 @@ lto = true
 debug = false
 panic = "abort"
 overflow-checks = true
-

--- a/aurora-locker/src/Codec.sol
+++ b/aurora-locker/src/Codec.sol
@@ -9,6 +9,14 @@ import "./Utils.sol";
 library Codec {
     using Borsh for Borsh.Data;
 
+    function encodeU8(uint8 v) internal pure returns (bytes1) {
+        return bytes1(v);
+    }
+
+    function encodeU16(uint16 v) internal pure returns (bytes2) {
+        return bytes2(Utils.swapBytes2(v));
+    }
+
     function encodeU32(uint32 v) public pure returns (bytes4) {
         return bytes4(Utils.swapBytes4(v));
     }

--- a/near-token-common/src/types.rs
+++ b/near-token-common/src/types.rs
@@ -69,3 +69,15 @@ impl From<[u8; 20]> for Address {
         Self(address)
     }
 }
+
+/// Similar to FungibleTokenMetadata. However, all fields are optional such that the user
+/// can specify any subset of it to be updated.
+#[derive(Deserialize, Serialize, Default)]
+pub struct UpdateFungibleTokenMetadata {
+    pub name: Option<String>,
+    pub symbol: Option<String>,
+    pub icon: Option<String>,
+    pub reference: Option<String>,
+    pub reference_hash: Option<near_sdk::json_types::Base64VecU8>,
+    pub decimals: Option<u8>,
+}

--- a/near-token-contract/Cargo.toml
+++ b/near-token-contract/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 near-contract-standards.workspace = true
 near-sdk.workspace = true
+near-token-common.workspace = true
 uint.workspace = true
-near-token-common = { path = "../near-token-common" }
 
 [dev-dependencies]

--- a/near-token-contract/src/lib.rs
+++ b/near-token-contract/src/lib.rs
@@ -18,6 +18,22 @@ mod ext;
 const GAS_FOR_UNLOCKING_TOKENS: Gas = Gas(10_000_000_000_000);
 const GAS_FOR_ON_WITHDRAW: Gas = Gas(10_000_000_000_000 + GAS_FOR_UNLOCKING_TOKENS.0);
 
+macro_rules! maybe_update_metadata {
+    ($self:ident, $field_name:ident) => {
+        if let Some($field_name) = $field_name {
+            $self.metadata.$field_name = $field_name
+        }
+    };
+}
+
+macro_rules! maybe_update_optional_metadata {
+    ($self:ident, $field_name:ident) => {
+        if let Some($field_name) = $field_name {
+            $self.metadata.$field_name = Some($field_name)
+        }
+    };
+}
+
 #[derive(BorshDeserialize, BorshSerialize, BorshStorageKey)]
 enum StorageKeys {
     FungibleToken,
@@ -225,12 +241,12 @@ impl Contract {
         } = metadata;
 
         // Update only parts of the metadata that were specified.
-        name.map(|name| self.metadata.name = name);
-        symbol.map(|symbol| self.metadata.symbol = symbol);
-        icon.map(|icon| self.metadata.icon = Some(icon));
-        reference.map(|reference| self.metadata.reference = Some(reference));
-        reference_hash.map(|reference_hash| self.metadata.reference_hash = Some(reference_hash));
-        decimals.map(|decimals| self.metadata.decimals = decimals);
+        maybe_update_metadata!(self, name);
+        maybe_update_metadata!(self, symbol);
+        maybe_update_optional_metadata!(self, icon);
+        maybe_update_optional_metadata!(self, reference);
+        maybe_update_optional_metadata!(self, reference_hash);
+        maybe_update_metadata!(self, decimals);
     }
 
     /// Triggers call in ERC20 Locker contract on Aurora to update the metadata of

--- a/near-token-factory/Cargo.toml
+++ b/near-token-factory/Cargo.toml
@@ -9,10 +9,10 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk.workspace = true
-uint.workspace = true
 hex.workspace = true
-near-token-common = { path = "../near-token-common" }
+near-sdk.workspace = true
+near-token-common.workspace = true
+uint.workspace = true
 
 [dev-dependencies]
 ethabi.workspace = true

--- a/near-token-factory/src/ext.rs
+++ b/near-token-factory/src/ext.rs
@@ -1,4 +1,5 @@
 use near_sdk::ext_contract;
+use near_token_common as aurora_sdk;
 
 #[ext_contract(ext_near_token)]
 pub trait ExtNearToken {
@@ -10,4 +11,6 @@ pub trait ExtNearToken {
         amount: near_sdk::json_types::U128,
         memo: Option<String>,
     );
+
+    fn update_metadata(&mut self, metadata: aurora_sdk::UpdateFungibleTokenMetadata);
 }


### PR DESCRIPTION
Without metadata, any application's tokens on NEAR are hard to use. This PR creates a process to move the metadata from Aurora to NEAR in a secure way but not depending on a trusted party. In particular, the method `update_metadata` on the token contract is expected to be open for a trusted party for setting icons and references.

Missing: A method on NEAR side to pull the metadata from Aurora.