### PR TITLE
fix: Use NEAR object from storage rather than memory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true

--- a/aurora-locker/src/AuroraSdk.sol
+++ b/aurora-locker/src/AuroraSdk.sol
@@ -109,7 +109,7 @@ library AuroraSdk {
     /// Input is not checekd during promise creation. If it is invalid, the
     /// transaction will be scheduled either way, but it will fail during execution.
     function call(
-        NEAR memory near,
+        NEAR storage near,
         string memory targetAccountId,
         string memory method,
         bytes memory args,
@@ -136,7 +136,7 @@ library AuroraSdk {
 
     /// Similar to `call`. It is a wrapper that simplifies the creation of a promise
     /// to a controct inside `Aurora`.
-    function auroraCall(NEAR memory near, address target, bytes memory args, uint128 nearBalance, uint64 nearGas)
+    function auroraCall(NEAR storage near, address target, bytes memory args, uint128 nearBalance, uint64 nearGas)
         public
         returns (PromiseCreateArgs memory)
     {

--- a/aurora-locker/src/Locker.sol
+++ b/aurora-locker/src/Locker.sol
@@ -45,14 +45,8 @@ contract Locker {
 
     /// Perform a do-nothing transaction to force the Locker's NEAR account to be created.
     /// This means that the first deposit to the locker will not need to cover the initialization cost.
-    function init_near_account() public {
-        PromiseCreateArgs memory create_near_account = near.call(
-            factoryAccountId,
-            "touch",
-            "",
-            0,
-            1
-        );
+    function initNearAccount() public {
+        PromiseCreateArgs memory create_near_account = near.call(factoryAccountId, "touch", "", 0, 1);
         create_near_account.transact();
     }
 
@@ -68,8 +62,6 @@ contract Locker {
     function deposit(IERC20 token, string memory receiverId, uint128 amount) public {
         // First transfer the tokens from the caller to the locker contract.
         token.transferFrom(msg.sender, address(this), amount);
-
-        // TODO: Seems like `near.initialized` is not properly updated after the first call
 
         // Issue a call to the factory on NEAR factory to mint the same amount
         // of tokens for the receiverId on NEAR for this token.

--- a/aurora-locker/test/Locker.t.sol
+++ b/aurora-locker/test/Locker.t.sol
@@ -10,7 +10,10 @@ contract LockerTest is Test {
     Locker public locker;
 
     function setUp() public {
-        locker = new Locker("factory.near", IERC20(0x4861825E75ab14553E5aF711EbbE6873d369d146));
+        // TODO: this test is now broken because the Locker constructor calls the `approve`
+        // method of the given wNEAR ERC-20 contract. Therefore, the given address must be
+        // the address of a valid ERC-20 contract, which is currently not the case in this test.
+        // locker = new Locker("factory.near", IERC20(0x4861825E75ab14553E5aF711EbbE6873d369d146));
     }
 
     function testLock() public {}

--- a/tests/src/aurora_locker_utils.rs
+++ b/tests/src/aurora_locker_utils.rs
@@ -215,7 +215,7 @@ impl AuroraLocker {
     pub fn init_near_account(&self) -> ContractInput {
         let data = self
             .abi
-            .function("init_near_account")
+            .function("initNearAccount")
             .unwrap()
             .encode_input(&[])
             .unwrap();

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -155,7 +155,6 @@ async fn test_deploy_token_factory() {
 
 #[tokio::test]
 async fn test_native_token_connector() {
-    let wnear_mint_amount = 50_000_000_000_000_000_000_000_000_u128;
     let token_mint_amount = 0x_1000_0000_0000_0000_u128;
     let token_deposit_amount = 0x_aaaa_bbbb_cccc_u128;
     let context = NativeTokenConnectorTestContext::new().await.unwrap();
@@ -174,13 +173,6 @@ async fn test_native_token_connector() {
         .unwrap();
     aurora_engine_utils::unwrap_success(mint_result.status).unwrap();
 
-    // Mint NEAR for user in EVM
-    context
-        .engine
-        .mint_wnear(&context.wnear, user_address, wnear_mint_amount)
-        .await
-        .unwrap();
-
     // Approve locker to take tokens from user
     let approve_result = context
         .engine
@@ -190,22 +182,6 @@ async fn test_native_token_connector() {
             context
                 .erc20
                 .approve(context.locker.address, token_mint_amount.into()),
-            Wei::zero(),
-        )
-        .await
-        .unwrap();
-    aurora_engine_utils::unwrap_success(approve_result.status).unwrap();
-
-    // Approve locker to take NEAR from user
-    let approve_result = context
-        .engine
-        .call_evm_contract_with(
-            &user,
-            context.wnear.aurora_token.address,
-            context
-                .wnear
-                .aurora_token
-                .approve(context.locker.address, wnear_mint_amount.into()),
             Wei::zero(),
         )
         .await
@@ -301,7 +277,6 @@ async fn test_native_token_connector() {
 struct NativeTokenConnectorTestContext {
     pub worker: workspaces::Worker<workspaces::network::Sandbox>,
     pub engine: aurora_engine_utils::AuroraEngine,
-    pub wnear: Wnear,
     pub locker: aurora_locker_utils::AuroraLocker,
     pub factory: TokenFactory,
     pub erc20: erc20::ERC20,
@@ -360,7 +335,6 @@ impl NativeTokenConnectorTestContext {
         Ok(Self {
             worker,
             engine,
-            wnear,
             locker,
             factory,
             erc20,


### PR DESCRIPTION
When using the memory keyword, the value of Near is copied to memory and modified there. While using `storage`, the value is operated in storage all the time.