### PR TITLE
Separate out flow from creating a token using the factory from the deposit flow

### DIFF
--- a/aurora-locker/src/AuroraSdk.sol
+++ b/aurora-locker/src/AuroraSdk.sol
@@ -56,7 +56,12 @@ library AuroraSdk {
     /// Compute NEAR represtentative account for the given Aurora address.
     /// This is the NEAR account created by the cross contract call precompile.
     function nearRepresentative(address account) public returns (string memory) {
-        return string(abi.encodePacked(Utils.bytesToHex(abi.encodePacked((bytes20(account)))), ".", currentAccountId()));
+        return addressSubAccount(account, currentAccountId());
+    }
+
+    /// Prepends the given account ID with the given address (hex-encoded).
+    function addressSubAccount(address account, string memory accountId) public pure returns (string memory) {
+        return string(abi.encodePacked(Utils.bytesToHex(abi.encodePacked((bytes20(account)))), ".", accountId));
     }
 
     /// Compute implicity Aurora Address for the given NEAR account.

--- a/aurora-locker/src/Locker.sol
+++ b/aurora-locker/src/Locker.sol
@@ -43,7 +43,7 @@ contract Locker {
     address public immutable selfReprsentativeImplicitAddress;
     /// An address is present in this mapping with a non-zero value if the corresponding NEAR
     /// token has been created.
-    mapping(IERC20 => uint) public registeredTokens;
+    mapping(IERC20 => uint256) public registeredTokens;
 
     constructor(string memory factoryAccountId_, IERC20 wNEAR) {
         factoryAccountId = factoryAccountId_;
@@ -69,11 +69,7 @@ contract Locker {
         // Require user to cover the cost of creating a new token by
         // attaching a balance of `NEW_TOKEN_DEPOSIT_COST`.
         PromiseCreateArgs memory createOnNear = near.call(
-            factoryAccountId,
-            "create_token",
-            abi.encodePacked(token),
-            NEW_TOKEN_DEPOSIT_COST,
-            CREATE_NEAR_GAS
+            factoryAccountId, "create_token", abi.encodePacked(token), NEW_TOKEN_DEPOSIT_COST, CREATE_NEAR_GAS
         );
 
         createOnNear.transact();

--- a/aurora-locker/src/Locker.sol
+++ b/aurora-locker/src/Locker.sol
@@ -7,9 +7,15 @@ import "./AuroraSdk.sol";
 
 string constant ERR_METHOD_NOT_IMPLEMENTED = "ERR_METHOD_NOT_IMPLEMENTED";
 // TODO: Determine proper values for gas.
-uint64 constant ON_DEPOSIT_NEAR_GAS = 50_000_000_000_000;
+uint64 constant ON_DEPOSIT_NEAR_GAS = 25_000_000_000_000;
+// TODO: Determine proper values for gas.
+uint64 constant CREATE_NEAR_GAS = 50_000_000_000_000;
 // TODO: Determine proper values for gas.
 uint64 constant DEPOSIT_CALLBACK_NEAR_GAS = 15_000_000_000_000;
+// TODO: Determine proper values for gas.
+uint64 constant STORAGE_DEPOSIT_NEAR_GAS = 5_000_000_000_000;
+uint128 constant NEW_TOKEN_DEPOSIT_COST = 3_000_000_000_000_000_000_000_000;
+uint128 constant STORAGE_DEPOSIT_COST = 1_250_000_000_000_000_000_000;
 
 // TODO: Implement Pause mechanics.
 // TODO: Implement Upgradable mechanics.
@@ -35,6 +41,9 @@ contract Locker {
     NEAR public near;
     /// Implicit address for representative NEAR account of this contract.
     address public immutable selfReprsentativeImplicitAddress;
+    /// An address is present in this mapping with a non-zero value if the corresponding NEAR
+    /// token has been created.
+    mapping(IERC20 => uint) public registeredTokens;
 
     constructor(string memory factoryAccountId_, IERC20 wNEAR) {
         factoryAccountId = factoryAccountId_;
@@ -50,6 +59,45 @@ contract Locker {
         create_near_account.transact();
     }
 
+    /// Function to bridge a new token to NEAR. Must be called before the token will
+    /// be accepted by `deposit`.
+    function createToken(IERC20 token) public {
+        require(registeredTokens[token] == 0, "ERR_TOKEN_ALREADY_REGISTERED");
+
+        registeredTokens[token] = 1;
+
+        // Require user to cover the cost of creating a new token by
+        // attaching a balance of `NEW_TOKEN_DEPOSIT_COST`.
+        PromiseCreateArgs memory createOnNear = near.call(
+            factoryAccountId,
+            "create_token",
+            abi.encodePacked(token),
+            NEW_TOKEN_DEPOSIT_COST,
+            CREATE_NEAR_GAS
+        );
+
+        createOnNear.transact();
+    }
+
+    /// Pays the NEP-141 storage deposit of the given token for the given account ID.
+    function storageDeposit(IERC20 token, string memory accountId) public {
+        require(registeredTokens[token] > 0, "ERR_TOKEN_NOT_FOUND");
+
+        string memory tokenAccountId = AuroraSdk.addressSubAccount(address(token), factoryAccountId);
+
+        // Require user to cover the cost of the storage deposit by
+        // attaching a balance of `NEW_TOKEN_DEPOSIT_COST`.
+        PromiseCreateArgs memory storageDepositOnNear = near.call(
+            tokenAccountId,
+            "storage_deposit",
+            abi.encodePacked("{\"account_id\":\"", accountId, "\"}"),
+            STORAGE_DEPOSIT_COST,
+            STORAGE_DEPOSIT_NEAR_GAS
+        );
+
+        storageDepositOnNear.transact();
+    }
+
     /// ERC20 tokens are locked in this contract, while the equivalent
     /// amount is minted on NEAR, in a contract implementing the NEP141
     /// interface. The user must approve this contract for the amount to
@@ -60,6 +108,8 @@ contract Locker {
     /// If the transaction fails, the tokens are automatically returned to
     /// the sender of the transaction.
     function deposit(IERC20 token, string memory receiverId, uint128 amount) public {
+        require(registeredTokens[token] > 0, "ERR_TOKEN_NOT_FOUND");
+
         // First transfer the tokens from the caller to the locker contract.
         token.transferFrom(msg.sender, address(this), amount);
 
@@ -115,17 +165,6 @@ contract Locker {
 
         // Transfer the tokens to the receiver.
         token.transfer(receiver, amount);
-    }
-
-    /// Create NEP141 compatible contract on NEAR for any ERC20 token.
-    ///
-    /// This function CAN be called at most once per token. Subsequent
-    /// times will have no effect, or could potentially fail. There is no
-    /// restriction on who can call this function.
-    function register(
-        IERC20Metadata //token
-    ) public pure {
-        require(false, ERR_METHOD_NOT_IMPLEMENTED);
     }
 
     /// Transfer ERC20 tokens from Aurora to NEAR chain and execute a

--- a/near-token-contract/src/lib.rs
+++ b/near-token-contract/src/lib.rs
@@ -74,10 +74,6 @@ impl Contract {
         // Only the factory can deposit tokens
         self.assert_factory();
 
-        // TODO: Is it ok if the contract auto-registers receiver on deposit?
-        // If not, the flow to create a new token needs to be reconsidered.
-        self.token.storage_deposit(Some(receiver_id.clone()), None);
-
         // Mint exact amount of tokens for the receiver
         self.token.internal_deposit(&receiver_id, amount.into());
 

--- a/near-token-factory/src/lib.rs
+++ b/near-token-factory/src/lib.rs
@@ -6,6 +6,7 @@ use near_sdk::{
 use near_token_common as aurora_sdk;
 mod ext;
 
+const NEW_TOKEN_DEPOSIT_COST: Balance = 3_000_000_000_000_000_000_000_000;
 const TOKEN_STORAGE_DEPOSIT_COST: Balance = 1_250_000_000_000_000_000_000;
 const TOKEN_DEPLOYMENT_COST: Gas = Gas(5_000_000_000_000);
 const DEPOSIT_COST: Gas = Gas(5_000_000_000_000);
@@ -14,6 +15,8 @@ const ERR_ONLY_LOCKER: &str = "ERR_ONLY_LOCKER: Only locker can call this method
 const ERR_INVALID_ACCOUNT: &str =
     "ERR_INVALID_ACCOUNT: Account ID too large. Impossible to create token subcontracts.";
 const ERR_BINARY_NOT_AVAILABLE: &str = "ERR_BINARY_NOT_AVAILABLE: Token binary is not set.";
+const ERR_TOKEN_NOT_FOUND: &str =
+    "ERR_TOKEN_NOT_FOUND: No token associated with given Aurora EVM address.";
 
 pub const WITHDRAW_SELECTOR: [u8; 4] = [0xd9, 0xca, 0xed, 0x12];
 
@@ -82,14 +85,22 @@ impl Contract {
 
     /// Create a new token by deploying the current binary in a sub-account. This method
     /// can only be called by the locker.
-    pub fn create_token(&mut self, token_address: aurora_sdk::Address) -> Promise {
+    #[payable]
+    pub fn create_token(
+        &mut self,
+        #[serializer(borsh)] token_address: aurora_sdk::Address,
+    ) -> Promise {
         self.assert_locker();
 
         let token_account_id = account_id_from_token_address(token_address);
         let binary = self.get_token_binary();
 
+        self.tokens
+            .insert(&token_account_id, &self.token_binary_version);
+
         Promise::new(token_account_id)
             .create_account()
+            .transfer(NEW_TOKEN_DEPOSIT_COST)
             .deploy_contract(binary)
             .function_call(
                 "new".to_string(),
@@ -113,42 +124,14 @@ impl Contract {
 
         let token_account_id = account_id_from_token_address(token);
 
-        if self.tokens.get(&token_account_id).is_none() {
-            let binary = self.get_token_binary();
+        require!(
+            self.tokens.get(&token_account_id).is_some(),
+            ERR_TOKEN_NOT_FOUND
+        );
 
-            // Register new token.
-            self.tokens
-                .insert(&token_account_id, &self.token_binary_version);
-
-            // The token doesn't exist yet, so we deploy it and initialize it and deposit in a single
-            // batched transaction.
-            Promise::new(token_account_id)
-                .create_account()
-                .transfer(3_000_000_000_000_000_000_000_000) // TODO: cost for storage should be covered by user?
-                .deploy_contract(binary)
-                .function_call(
-                    "new".to_string(),
-                    vec![],
-                    TOKEN_STORAGE_DEPOSIT_COST,
-                    TOKEN_DEPLOYMENT_COST,
-                )
-                .function_call(
-                    "deposit".to_string(),
-                    near_sdk::serde_json::json!({
-                        "receiver_id": receiver_id,
-                        "amount": amount.to_string(),
-                    })
-                    .to_string()
-                    .into_bytes(),
-                    // TODO: auto-register user for new tokens?
-                    TOKEN_STORAGE_DEPOSIT_COST,
-                    DEPOSIT_COST,
-                )
-        } else {
-            ext::ext_near_token::ext(token_account_id)
-                .with_static_gas(DEPOSIT_COST)
-                .deposit(receiver_id, amount.into(), None)
-        }
+        ext::ext_near_token::ext(token_account_id)
+            .with_static_gas(DEPOSIT_COST)
+            .deposit(receiver_id, amount.into(), None)
     }
 
     /// Method invoked by each individual token when an account id calls `withdraw`.

--- a/tests/src/aurora_locker_utils.rs
+++ b/tests/src/aurora_locker_utils.rs
@@ -221,6 +221,33 @@ impl AuroraLocker {
             .unwrap();
         ContractInput(data)
     }
+
+    pub fn create_token(&self, token: Address) -> ContractInput {
+        let data = self
+            .abi
+            .function("createToken")
+            .unwrap()
+            .encode_input(&[ethabi::Token::Address(token.raw())])
+            .unwrap();
+        ContractInput(data)
+    }
+
+    pub fn storage_deposit(
+        &self,
+        token: Address,
+        account_id: &workspaces::AccountId,
+    ) -> ContractInput {
+        let data = self
+            .abi
+            .function("storageDeposit")
+            .unwrap()
+            .encode_input(&[
+                ethabi::Token::Address(token.raw()),
+                ethabi::Token::String(account_id.as_str().into()),
+            ])
+            .unwrap();
+        ContractInput(data)
+    }
 }
 
 pub trait LockerDeployedAt {


### PR DESCRIPTION
Also require user to explicitly provide a storage deposit before depositing tokens into the locker.

This PR addresses some issues raised in #15 