### PR TITLE
Feat: CLI for working with native ERC-20 token connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "aurora-engine"
 version = "2.7.0"
 source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.7.0#22c176c572bc32e9951348892401d9039b8efef8"
@@ -549,6 +560,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +610,11 @@ name = "connector-cli"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "clap",
+ "near-account-id 0.15.0",
+ "near-token-common",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -2162,6 +2215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,6 +3087,15 @@ dependencies = [
  "redox_syscall 0.2.16",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3432,6 +3506,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "hex 0.4.3",
  "rjson",
  "rlp",
+ "serde",
  "wee_alloc",
 ]
 
@@ -219,6 +220,7 @@ dependencies = [
  "aurora-engine-types",
  "evm",
  "rlp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ name = "connector-cli"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "near-account-id 0.15.0",
  "near-token-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "borsh",
  "hex 0.4.3",
  "primitive-types 0.11.1",
+ "serde",
 ]
 
 [[package]]
@@ -611,8 +612,14 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aurora-engine",
+ "aurora-engine-types",
+ "base64 0.13.0",
+ "borsh",
  "chrono",
  "clap",
+ "ethabi",
+ "hex 0.4.3",
  "near-account-id 0.15.0",
  "near-crypto 0.15.0",
  "near-jsonrpc-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,9 +610,14 @@ name = "connector-cli"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "near-account-id 0.15.0",
+ "near-crypto 0.15.0",
+ "near-jsonrpc-client",
+ "near-jsonrpc-primitives",
+ "near-primitives 0.15.0",
  "near-token-common",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-cli"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "tokio",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-e
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 base64 = "0.13.0"
 borsh = "0.9"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0", features = ["derive"] }
 ethabi = "17.2"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", t
 aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0", features = ["impl-serde"] }
 base64 = "0.13.0"
 borsh = "0.9"
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.15.0"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1.58"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0", features = ["impl-serde"] }
 aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-e
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 base64 = "0.13.0"
 borsh = "0.9"
+clap = { version = "4.0", features = ["derive"] }
 ethabi = "17.2"
 hex = "0.4"
+near-account-id = "0.15.0"
 near-contract-standards = "4.0.0"
 near-sdk = "4.0.0"
 near-token-common = { path = "near-token-common" }
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.18", features = ["full"] }
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "connector-cli",
   "near-token-common",
   "near-token-contract",
   "near-token-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.15.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+async-trait = "0.1.58"
 aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
 aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.7.0" }
@@ -25,7 +26,11 @@ clap = { version = "4.0", features = ["derive"] }
 ethabi = "17.2"
 hex = "0.4"
 near-account-id = "0.15.0"
+near-crypto = "0.15.0"
 near-contract-standards = "4.0.0"
+near-jsonrpc-client = "0.4.0"
+near-jsonrpc-primitives = "0.15.0"
+near-primitives = "0.15.0"
 near-sdk = "4.0.0"
 near-token-common = { path = "near-token-common" }
 serde = { version = "1", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ near-token-contract:
 aurora-locker:
 	cd aurora-locker; $(FORGE) build
 
+aurora-locker-sdk:
+	cd aurora-locker; $(FORGE) build --libraries src/Codec.sol:Codec:$(CODEC) --libraries src/Utils.sol:Utils:$(UTILS)
+
+aurora-locker-with-libs:
+	cd aurora-locker; $(FORGE) build --libraries src/Codec.sol:Codec:$(CODEC) --libraries src/AuroraSdk.sol:AuroraSdk:$(SDK)
+
 test:
 	$(CARGO) test
 
@@ -35,4 +41,4 @@ check-clippy:
 clean:
 	$(CARGO) clean
 
-.PHONY: check clean near-token-factory near-token-contract aurora-locker check-compile check-fmt check-clippy test
+.PHONY: check clean near-token-factory near-token-contract aurora-locker aurora-locker-sdk aurora-locker-with-libs check-compile check-fmt check-clippy test

--- a/connector-cli/Cargo.toml
+++ b/connector-cli/Cargo.toml
@@ -8,8 +8,14 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+aurora-engine.workspace = true
+aurora-engine-types.workspace = true
+base64.workspace = true
+borsh.workspace = true
 chrono.workspace = true
 clap.workspace = true
+ethabi.workspace = true
+hex.workspace = true
 near-account-id.workspace = true
 near-crypto.workspace = true
 near-jsonrpc-client.workspace = true

--- a/connector-cli/Cargo.toml
+++ b/connector-cli/Cargo.toml
@@ -7,9 +7,14 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 chrono.workspace = true
 clap.workspace = true
 near-account-id.workspace = true
+near-crypto.workspace = true
+near-jsonrpc-client.workspace = true
+near-jsonrpc-primitives.workspace = true
+near-primitives.workspace = true
 near-token-common.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/connector-cli/Cargo.toml
+++ b/connector-cli/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+chrono.workspace = true
 clap.workspace = true
 near-account-id.workspace = true
 near-token-common.workspace = true

--- a/connector-cli/Cargo.toml
+++ b/connector-cli/Cargo.toml
@@ -7,4 +7,9 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
+near-account-id.workspace = true
+near-token-common.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true

--- a/connector-cli/Cargo.toml
+++ b/connector-cli/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "connector-cli"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+tokio.workspace = true

--- a/connector-cli/README.md
+++ b/connector-cli/README.md
@@ -1,0 +1,3 @@
+# Native ERC-20 Connector CLI
+
+TODO: documentation

--- a/connector-cli/config.json
+++ b/connector-cli/config.json
@@ -1,6 +1,8 @@
 {
   "near_rpc_url": "https://archival-rpc.testnet.near.org/",
   "aurora_rpc_url": null,
+  "aurora_account_id": "aurora",
+  "wnear_address": "0x4861825e75ab14553e5af711ebbe6873d369d146",
   "factory_account_id": "factory.testnet",
   "locker_address": null,
   "log_path": "connector_cli.log",

--- a/connector-cli/config.json
+++ b/connector-cli/config.json
@@ -1,0 +1,9 @@
+{
+  "near_rpc_url": "https://archival-rpc.testnet.near.org/",
+  "aurora_rpc_url": null,
+  "factory_account_id": "factory.testnet",
+  "locker_address": null,
+  "signing": null,
+  "repository_root": null,
+  "use_aurora_rpc": false
+}

--- a/connector-cli/config.json
+++ b/connector-cli/config.json
@@ -6,5 +6,7 @@
   "log_path": "connector_cli.log",
   "signing": null,
   "repository_root": null,
-  "use_aurora_rpc": false
+  "use_aurora_rpc": false,
+  "allow_changed_files": false,
+  "allow_deploy_overwrite": false
 }

--- a/connector-cli/config.json
+++ b/connector-cli/config.json
@@ -3,6 +3,7 @@
   "aurora_rpc_url": null,
   "factory_account_id": "factory.testnet",
   "locker_address": null,
+  "log_path": "connector_cli.log",
   "signing": null,
   "repository_root": null,
   "use_aurora_rpc": false

--- a/connector-cli/src/cli.rs
+++ b/connector-cli/src/cli.rs
@@ -14,5 +14,10 @@ pub struct Args {
 pub enum Command {
     /// Write a default config to `config_path`
     InitConfig,
+    /// Deploy the Locker and Factory contracts on-chain
     Deploy,
+    /// Add a new Aurora-native ERC-20 token to the connector. This will create a NEP-141
+    /// counterpart of the token on NEAR. This command will fail if the given address is
+    /// already registered with the native token connector.
+    CreateToken { address: String },
 }

--- a/connector-cli/src/cli.rs
+++ b/connector-cli/src/cli.rs
@@ -1,0 +1,18 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Path to the config file. By default, assumes `config.json` in the current directory.
+    #[arg(short, long)]
+    pub config_path: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Write a default config to `config_path`
+    InitConfig,
+    Deploy,
+}

--- a/connector-cli/src/config.rs
+++ b/connector-cli/src/config.rs
@@ -9,6 +9,10 @@ pub struct Config {
     pub near_rpc_url: String,
     /// URL for the RPC to interact with the Aurora Engine. Must be given if `use_aurora_rpc` is true.
     pub aurora_rpc_url: Option<String>,
+    /// AccountId of Aurora Engine contract
+    pub aurora_account_id: AccountId,
+    /// Address of the (bridged) wrapped Near contract on Aurora.
+    pub wnear_address: near_token_common::types::Address,
     /// AccountId where `near-token-factory` is deployed (or will be deployed).
     pub factory_account_id: AccountId,
     /// Aurora Address where `aurora-locker` is deployed,
@@ -62,6 +66,13 @@ impl Config {
         Self {
             near_rpc_url: "https://archival-rpc.testnet.near.org/".into(),
             aurora_rpc_url: None,
+            aurora_account_id: "aurora".parse().unwrap(),
+            wnear_address: near_token_common::Address(
+                hex::decode("4861825e75ab14553e5af711ebbe6873d369d146")
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            ),
             factory_account_id: "factory.testnet".parse().unwrap(),
             locker_address: None,
             log_path: "connector_cli.log".into(),

--- a/connector-cli/src/config.rs
+++ b/connector-cli/src/config.rs
@@ -1,4 +1,5 @@
 use near_account_id::AccountId;
+use near_crypto::KeyFile;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -24,6 +25,13 @@ pub struct Config {
     /// If `true` then use the Aurora RPC to interact with the Aurora Engine, otherwise the
     /// Engine's `call` method will be used from the signer for `factory_account_id`.
     pub use_aurora_rpc: bool,
+    /// If `true` then allow the `deploy` command to continue even if there are modified
+    /// files in the repository.
+    pub allow_changed_files: bool,
+    /// If `true` then allow the `deploy` command to overwrite code already deployed
+    /// to the factory account. Otherwise, `deploy` requires the factory account
+    /// to not have any code already (but it must already exist).
+    pub allow_deploy_overwrite: bool,
 }
 
 impl Config {
@@ -39,6 +47,17 @@ impl Config {
         Ok(())
     }
 
+    pub fn get_near_key(&self) -> anyhow::Result<KeyFile> {
+        let key_path = self
+            .signing
+            .as_ref()
+            .ok_or_else(|| anyhow::Error::msg("Missing signing config"))?
+            .near_key_path
+            .as_str();
+        let key = KeyFile::from_file(Path::new(key_path))?;
+        Ok(key)
+    }
+
     pub fn testnet() -> Self {
         Self {
             near_rpc_url: "https://archival-rpc.testnet.near.org/".into(),
@@ -49,6 +68,8 @@ impl Config {
             signing: None,
             repository_root: None,
             use_aurora_rpc: false,
+            allow_changed_files: false,
+            allow_deploy_overwrite: false,
         }
     }
 }

--- a/connector-cli/src/config.rs
+++ b/connector-cli/src/config.rs
@@ -1,0 +1,63 @@
+use near_account_id::AccountId;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    /// URL for the RPC to interact with the NEAR network.
+    pub near_rpc_url: String,
+    /// URL for the RPC to interact with the Aurora Engine. Must be given if `use_aurora_rpc` is true.
+    pub aurora_rpc_url: Option<String>,
+    /// AccountId where `near-token-factory` is deployed (or will be deployed).
+    pub factory_account_id: AccountId,
+    /// Aurora Address where `aurora-locker` is deployed,
+    /// or `null` if the locker is not yet deployed.
+    pub locker_address: Option<near_token_common::types::Address>,
+    /// Credentials used for signing transactions. Must be given if executing transactions
+    /// that change the state (e.g. `deploy`).
+    pub signing: Option<Signing>,
+    /// Path to the `native-erc20-connector` repository.
+    /// If `null`, then it is assumed to be the current directory.
+    pub repository_root: Option<String>,
+    /// If `true` then use the Aurora RPC to interact with the Aurora Engine, otherwise the
+    /// Engine's `call` method will be used from the signer for `factory_account_id`.
+    pub use_aurora_rpc: bool,
+}
+
+impl Config {
+    pub async fn from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let bytes = tokio::fs::read(path).await?;
+        let result = serde_json::from_slice(&bytes)?;
+        Ok(result)
+    }
+
+    pub async fn write_file<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<()> {
+        let serialized = serde_json::to_string_pretty(&self)?;
+        tokio::fs::write(path, serialized.into_bytes()).await?;
+        Ok(())
+    }
+
+    pub fn testnet() -> Self {
+        Self {
+            near_rpc_url: "https://archival-rpc.testnet.near.org/".into(),
+            aurora_rpc_url: None,
+            factory_account_id: "factory.testnet".parse().unwrap(),
+            locker_address: None,
+            signing: None,
+            repository_root: None,
+            use_aurora_rpc: false,
+        }
+    }
+}
+
+// TODO: ledger support?
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Signing {
+    /// Path to a file containing a NEAR signing key, in the usual JSON format
+    /// (see https://docs.rs/near-crypto/0.15.0/near_crypto/struct.KeyFile.html).
+    pub near_key_path: String,
+    /// Path to a file containing a hex-encoded secp256k1 private key (32-bytes).
+    /// Must be provided if using Aurora RPC as opposed to NEAR RPC to interact
+    /// with the Aurora Engine.
+    pub aurora_key_path: Option<String>,
+}

--- a/connector-cli/src/config.rs
+++ b/connector-cli/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     /// Aurora Address where `aurora-locker` is deployed,
     /// or `null` if the locker is not yet deployed.
     pub locker_address: Option<near_token_common::types::Address>,
+    /// Path to file where logs are written
+    pub log_path: String,
     /// Credentials used for signing transactions. Must be given if executing transactions
     /// that change the state (e.g. `deploy`).
     pub signing: Option<Signing>,
@@ -43,6 +45,7 @@ impl Config {
             aurora_rpc_url: None,
             factory_account_id: "factory.testnet".parse().unwrap(),
             locker_address: None,
+            log_path: "connector_cli.log".into(),
             signing: None,
             repository_root: None,
             use_aurora_rpc: false,

--- a/connector-cli/src/create_token.rs
+++ b/connector-cli/src/create_token.rs
@@ -1,0 +1,103 @@
+use crate::{
+    config::Config,
+    log::{AuroraTransactionKind, EventKind, Log},
+    near_rpc_ext::{self, client_like::ClientLike, MAX_NEAR_GAS},
+};
+use aurora_engine::parameters::{CallArgs, FunctionCallArgsV2};
+use aurora_engine_types::types::Address;
+use borsh::BorshSerialize;
+use near_primitives::transaction;
+use std::sync::Arc;
+
+const CREATE_TOKEN_SELECTOR: [u8; 4] = [0, 0, 0, 0];
+
+pub async fn create_token<C: ClientLike>(
+    address: Address,
+    config: &Config,
+    near: Arc<C>,
+    key: &near_crypto::KeyFile,
+    log: &mut Log,
+) -> anyhow::Result<()> {
+    if config.use_aurora_rpc {
+        return Err(anyhow::Error::msg("Aurora RPC not yet supported"));
+    }
+
+    let locker_address = config
+        .locker_address
+        .as_ref()
+        .map(|a| Address::from_array(a.0))
+        .ok_or_else(|| anyhow::Error::msg("locker_address must be set in config"))?;
+    let key_info =
+        near_rpc_ext::query_access_key(config.factory_account_id.clone(), key.public_key.clone())
+            .spawn(near.clone())
+            .await??;
+    let nonce = key_info.data.nonce + 1;
+    let block_hash = key_info.block_hash;
+
+    let input = {
+        let mut buf = CREATE_TOKEN_SELECTOR.to_vec();
+        buf.extend_from_slice(&ethabi::encode(&[ethabi::Token::Address(address.raw())]));
+        buf
+    };
+    let args = CallArgs::V2(FunctionCallArgsV2 {
+        contract: locker_address,
+        value: [0u8; 32],
+        input,
+    });
+
+    let tx = transaction::Transaction {
+        signer_id: key.account_id.clone(),
+        public_key: key.public_key.clone(),
+        nonce,
+        receiver_id: config.aurora_account_id.clone(),
+        block_hash,
+        actions: vec![transaction::Action::FunctionCall(
+            transaction::FunctionCallAction {
+                method_name: "call".into(),
+                args: args.try_to_vec()?,
+                gas: MAX_NEAR_GAS,
+                deposit: 0,
+            },
+        )],
+    };
+
+    let signer = near_crypto::InMemorySigner::from_secret_key(
+        key.account_id.clone(),
+        key.secret_key.clone(),
+    );
+    let tx_hash = near_rpc_ext::broadcast_tx_async(tx.sign(&signer))
+        .spawn(near.clone())
+        .await??;
+    log.push(EventKind::NearTransactionSubmitted { hash: tx_hash });
+
+    let tx_status =
+        near_rpc_ext::wait_tx_executed(config.factory_account_id.clone(), tx_hash, near.as_ref())
+            .await?;
+    match tx_status {
+        Ok(return_bytes) => {
+            let result = near_rpc_ext::aurora_engine_utils::assume_successful_submit_result(
+                tx_hash,
+                &return_bytes,
+                log,
+            )?;
+            log.push(EventKind::AuroraTransactionSuccessful {
+                near_hash: Some(tx_hash),
+                aurora_hash: None,
+                kind: AuroraTransactionKind::ContractCall {
+                    address: locker_address,
+                    result,
+                },
+            });
+        }
+        Err(e) => {
+            let error_message = format!("create_token transaction failed: {:?}", e);
+            log.push(EventKind::NearTransactionFailed {
+                hash: tx_hash,
+                error: e,
+            });
+            return Err(anyhow::Error::msg(error_message));
+        }
+    }
+
+    Ok(())
+}

--- a/connector-cli/src/deploy.rs
+++ b/connector-cli/src/deploy.rs
@@ -1,0 +1,5 @@
+use crate::config::Config;
+
+pub async fn deploy(_config: &Config) -> anyhow::Result<()> {
+    todo!()
+}

--- a/connector-cli/src/deploy.rs
+++ b/connector-cli/src/deploy.rs
@@ -1,5 +1,58 @@
-use crate::config::Config;
+use crate::{
+    config::Config,
+    log::{EventKind, Log},
+};
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
 
-pub async fn deploy(_config: &Config) -> anyhow::Result<()> {
-    todo!()
+pub async fn deploy(config: &Config, log: &mut Log) -> anyhow::Result<()> {
+    let repository_root =
+        Path::new(config.repository_root.as_deref().unwrap_or(".")).canonicalize()?;
+
+    // `cargo` and `forge` compilations can be run in parallel.
+    let compile_factory_task = make("near-token-factory", &repository_root, log)?;
+    let compile_locker_task = make("aurora-locker", &repository_root, log)?;
+    // `near-token-factory` and `near-token-contract` are both `cargo` builds, so they must
+    // run sequentially. Therefore we wait until the factory is done before starting the token.
+    let compile_factory_result = compile_factory_task.await?;
+    let compile_token_task = make("near-token-contract", &repository_root, log)?;
+    let compile_token_result = compile_token_task.await?;
+    let compile_locker_result = compile_locker_task.await?;
+    // Ensure all compilation was successful
+    compile_factory_result?;
+    compile_token_result?;
+    compile_locker_result?;
+
+    // TODO: deploy compiled artifacts to chain
+
+    Ok(())
+}
+
+/// Spawning a task allows running multiple `make` commands in parallel.
+fn make(
+    command: &'static str,
+    repository_root: &PathBuf,
+    log: &mut Log,
+) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<()>>> {
+    let mut child = Command::new("make")
+        .current_dir(repository_root)
+        .arg(command)
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()?;
+    log.push(EventKind::Make {
+        command: command.into(),
+    });
+    let task = tokio::task::spawn(async move {
+        let output = child.wait().await?;
+        if output.success() {
+            Ok(())
+        } else {
+            Err(anyhow::Error::msg(format!(
+                "Error: command `make {}` failed.",
+                command
+            )))
+        }
+    });
+    Ok(task)
 }

--- a/connector-cli/src/deploy.rs
+++ b/connector-cli/src/deploy.rs
@@ -1,11 +1,24 @@
 use crate::{
     config::Config,
-    log::{EventKind, Log},
+    log::{EventKind, Log, NearTransactionKind},
+    near_rpc_ext::{self, client_like::ClientLike},
 };
-use std::path::{Path, PathBuf};
+use near_primitives::{transaction, views::AccessKeyPermissionView};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::process::Command;
 
-pub async fn deploy(config: &Config, log: &mut Log) -> anyhow::Result<()> {
+/// Path to the factory wasm artifact relative to the repository root.
+const FACTORY_WASM_PATH: &str = "target/wasm32-unknown-unknown/release/near_token_factory.wasm";
+
+pub async fn deploy<C: ClientLike>(
+    config: &Config,
+    near: Arc<C>,
+    key: &near_crypto::KeyFile,
+    log: &mut Log,
+) -> anyhow::Result<()> {
     let repository_root =
         Path::new(config.repository_root.as_deref().unwrap_or(".")).canonicalize()?;
 
@@ -23,7 +36,107 @@ pub async fn deploy(config: &Config, log: &mut Log) -> anyhow::Result<()> {
     compile_token_result?;
     compile_locker_result?;
 
-    // TODO: deploy compiled artifacts to chain
+    // Ensure no files were modified in the build process (unless config allows it)
+    if !config.allow_changed_files {
+        let output = Command::new("git").arg("diff").output().await?;
+        if !output.status.success() {
+            return Err(anyhow::Error::msg(format!(
+                "`git diff` failed: {:?} {:?}",
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout)
+            )));
+        }
+        if !output.stderr.is_empty() || !output.stdout.is_empty() {
+            return Err(anyhow::Error::msg(
+                "Deploy aborted due to changed files in git repository",
+            ));
+        }
+    }
+
+    // Submit multiple RPC requests for data we need for deployment in parallel
+    let maybe_key_info =
+        near_rpc_ext::query_access_key(config.factory_account_id.clone(), key.public_key.clone())
+            .spawn(near.clone());
+    let maybe_preexisting_contract =
+        near_rpc_ext::query_code(config.factory_account_id.clone()).spawn(near.clone());
+
+    // Wait for both requests to finish before checking the results
+    let maybe_key_info = maybe_key_info.await?;
+    let maybe_preexisting_contract = maybe_preexisting_contract.await?;
+
+    // Confirm we have the access key for the factory account (and get the nonce at the same time)
+    let key_info = maybe_key_info?;
+    let nonce = if let AccessKeyPermissionView::FullAccess = key_info.data.permission {
+        key_info.data.nonce
+    } else {
+        return Err(anyhow::Error::msg("FullAccess key required for deployment"));
+    };
+
+    // Confirm there is no code already deployed to the account (unless config allows it)
+    let preexisting_contract = maybe_preexisting_contract?.data;
+    if !config.allow_deploy_overwrite && !preexisting_contract.code.is_empty() {
+        return Err(anyhow::Error::msg(
+            "Deploy aborted due to a contract already deployed to factory account ID",
+        ));
+    }
+
+    // Deploy factory contract to NEAR
+    let factory_code = tokio::fs::read(repository_root.join(FACTORY_WASM_PATH)).await?;
+    let factory_deploy_tx = transaction::Transaction {
+        signer_id: config.factory_account_id.clone(),
+        public_key: key.public_key.clone(),
+        nonce,
+        receiver_id: config.factory_account_id.clone(),
+        block_hash: key_info.block_hash,
+        actions: vec![transaction::Action::DeployContract(
+            transaction::DeployContractAction { code: factory_code },
+        )],
+    };
+    let signer = near_crypto::InMemorySigner::from_secret_key(
+        config.factory_account_id.clone(),
+        key.secret_key.clone(),
+    );
+    let tx_hash = near_rpc_ext::broadcast_tx_async(factory_deploy_tx.sign(&signer))
+        .spawn(near.clone())
+        .await??;
+    log.push(EventKind::NearTransactionSubmitted { hash: tx_hash });
+
+    // Confirm deploy success and push events to the log
+    let tx_status =
+        near_rpc_ext::wait_tx_executed(config.factory_account_id.clone(), tx_hash, near.as_ref())
+            .await?;
+    match tx_status {
+        Ok(_) => {
+            let contract_info = near_rpc_ext::query_code(config.factory_account_id.clone())
+                .execute(near.as_ref())
+                .await?
+                .data;
+            let previous_code_hash = if preexisting_contract.code.is_empty() {
+                None
+            } else {
+                Some(preexisting_contract.hash)
+            };
+            log.push(EventKind::NearTransactionSuccessful {
+                hash: tx_hash,
+                kind: NearTransactionKind::DeployCode {
+                    account_id: config.factory_account_id.clone(),
+                    new_code_hash: contract_info.hash,
+                    previous_code_hash,
+                },
+            });
+        }
+        Err(e) => {
+            let error_message = format!("Deploy transaction failed: {:?}", e);
+            log.push(EventKind::NearTransactionFailed {
+                hash: tx_hash,
+                error: e,
+            });
+            return Err(anyhow::Error::msg(error_message));
+        }
+    }
+
+    // TODO: deploy locker contract to Aurora
+    // TODO: initialize the factory contract
 
     Ok(())
 }
@@ -34,23 +147,25 @@ fn make(
     repository_root: &PathBuf,
     log: &mut Log,
 ) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<()>>> {
-    let mut child = Command::new("make")
+    let child = Command::new("make")
         .current_dir(repository_root)
         .arg(command)
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
         .spawn()?;
     log.push(EventKind::Make {
         command: command.into(),
     });
     let task = tokio::task::spawn(async move {
-        let output = child.wait().await?;
-        if output.success() {
+        let output = child.wait_with_output().await?;
+        if output.status.success() {
             Ok(())
         } else {
             Err(anyhow::Error::msg(format!(
-                "Error: command `make {}` failed.",
-                command
+                "Error: command `make {}` failed. stderr={:?} stdout={:?}",
+                command,
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout),
             )))
         }
     });

--- a/connector-cli/src/log.rs
+++ b/connector-cli/src/log.rs
@@ -1,3 +1,5 @@
+use near_account_id::AccountId;
+use near_primitives::{errors::TxExecutionError, hash::CryptoHash};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
@@ -36,8 +38,32 @@ pub struct Event {
     pub kind: EventKind,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventKind {
-    Make { command: String },
-    InitConfig { new_config: crate::config::Config },
+    Make {
+        command: String,
+    },
+    InitConfig {
+        new_config: crate::config::Config,
+    },
+    NearTransactionSubmitted {
+        hash: CryptoHash,
+    },
+    NearTransactionSuccessful {
+        hash: CryptoHash,
+        kind: NearTransactionKind,
+    },
+    NearTransactionFailed {
+        hash: CryptoHash,
+        error: TxExecutionError,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum NearTransactionKind {
+    DeployCode {
+        account_id: AccountId,
+        new_code_hash: CryptoHash,
+        previous_code_hash: Option<CryptoHash>,
+    },
 }

--- a/connector-cli/src/log.rs
+++ b/connector-cli/src/log.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tokio::io::AsyncWriteExt;
+
+pub type DateTime = chrono::DateTime<chrono::Utc>;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Log {
+    pub events: Vec<Event>,
+}
+
+impl Log {
+    pub fn push(&mut self, kind: EventKind) {
+        let timestamp = chrono::Utc::now();
+        self.events.push(Event { timestamp, kind })
+    }
+
+    pub async fn append_to_file<P: AsRef<Path>>(self, path: P) -> anyhow::Result<()> {
+        let mut writer = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        for event in self.events {
+            let serialized = serde_json::to_string(&event)?;
+            writer.write_all(serialized.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+    pub timestamp: DateTime,
+    pub kind: EventKind,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum EventKind {
+    Make { command: String },
+    InitConfig { new_config: crate::config::Config },
+}

--- a/connector-cli/src/log.rs
+++ b/connector-cli/src/log.rs
@@ -1,4 +1,4 @@
-use aurora_engine::parameters::TransactionStatus;
+use aurora_engine::parameters::{SubmitResult, TransactionStatus};
 use aurora_engine_types::types::Address;
 use near_account_id::AccountId;
 use near_primitives::{errors::TxExecutionError, hash::CryptoHash};
@@ -116,7 +116,13 @@ pub enum NearTransactionKind {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AuroraTransactionKind {
-    DeployContract { address: Address },
+    DeployContract {
+        address: Address,
+    },
+    ContractCall {
+        address: Address,
+        result: SubmitResult,
+    },
 }
 
 mod serde_hex {

--- a/connector-cli/src/main.rs
+++ b/connector-cli/src/main.rs
@@ -1,0 +1,5 @@
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("Hello, world!");
+    Ok(())
+}

--- a/connector-cli/src/main.rs
+++ b/connector-cli/src/main.rs
@@ -1,5 +1,26 @@
+use clap::Parser;
+
+mod cli;
+mod config;
+mod deploy;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    println!("Hello, world!");
+    let args = cli::Args::parse();
+
+    let config_path = args.config_path.as_deref().unwrap_or("config.json");
+    let config = if let cli::Command::InitConfig = args.command {
+        let config = config::Config::testnet();
+        config.write_file(config_path).await?;
+        config
+    } else {
+        config::Config::from_file(config_path).await?
+    };
+
+    match args.command {
+        cli::Command::Deploy => deploy::deploy(&config).await?,
+        cli::Command::InitConfig => (),
+    }
+
     Ok(())
 }

--- a/connector-cli/src/main.rs
+++ b/connector-cli/src/main.rs
@@ -3,22 +3,44 @@ use clap::Parser;
 mod cli;
 mod config;
 mod deploy;
+mod log;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = cli::Args::parse();
 
+    let mut log = log::Log::default();
     let config_path = args.config_path.as_deref().unwrap_or("config.json");
     let config = if let cli::Command::InitConfig = args.command {
         let config = config::Config::testnet();
         config.write_file(config_path).await?;
+        log.push(crate::log::EventKind::InitConfig {
+            new_config: config.clone(),
+        });
         config
     } else {
         config::Config::from_file(config_path).await?
     };
 
-    match args.command {
-        cli::Command::Deploy => deploy::deploy(&config).await?,
+    let result = handle_command(args.command, &config, &mut log).await;
+
+    // Always write the logs, independent of whether the command completed successfully
+    log.append_to_file(&config.log_path)
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("Failed to write logs: {:?}", e)))?;
+
+    result?;
+
+    Ok(())
+}
+
+async fn handle_command(
+    command: cli::Command,
+    config: &crate::config::Config,
+    log: &mut log::Log,
+) -> anyhow::Result<()> {
+    match command {
+        cli::Command::Deploy => deploy::deploy(config, log).await?,
         cli::Command::InitConfig => (),
     }
 

--- a/connector-cli/src/main.rs
+++ b/connector-cli/src/main.rs
@@ -1,8 +1,10 @@
+use aurora_engine_types::types::Address;
 use clap::Parser;
 use std::sync::Arc;
 
 mod cli;
 mod config;
+mod create_token;
 mod deploy;
 mod log;
 mod near_rpc_ext;
@@ -55,6 +57,17 @@ async fn handle_command(
             ));
             let key = config.get_near_key()?;
             deploy::deploy(config, near, &key, log).await?
+        }
+        cli::Command::CreateToken { address } => {
+            let parsed_address = Address::decode(address.strip_prefix("0x").unwrap_or(&address))
+                .map_err(|e| {
+                    anyhow::Error::msg(format!("Invalid address {} provided: {:?}", address, e))
+                })?;
+            let near = Arc::new(near_jsonrpc_client::JsonRpcClient::connect(
+                &config.near_rpc_url,
+            ));
+            let key = config.get_near_key()?;
+            create_token::create_token(parsed_address, config, near, &key, log).await?
         }
         cli::Command::InitConfig => (),
     }

--- a/connector-cli/src/near_rpc_ext/aurora_engine_utils.rs
+++ b/connector-cli/src/near_rpc_ext/aurora_engine_utils.rs
@@ -1,0 +1,43 @@
+use crate::log::{AuroraTransactionError, EventKind, Log};
+use aurora_engine::parameters::{SubmitResult, TransactionStatus};
+use borsh::BorshDeserialize;
+use near_primitives::hash::CryptoHash;
+
+pub fn assume_successful_submit_result(
+    tx_hash: CryptoHash,
+    near_tx_output: &[u8],
+    log: &mut Log,
+) -> anyhow::Result<SubmitResult> {
+    let result = SubmitResult::try_from_slice(near_tx_output).map_err(|e| {
+        anyhow::Error::msg(format!(
+            "Failed to parse SubmitResult from Engine return: {:?}",
+            e
+        ))
+    })?;
+    match result.status {
+        TransactionStatus::Succeed(_) => Ok(result),
+        TransactionStatus::Revert(revert_bytes) => {
+            let error_message = format!(
+                "Deploy Aurora EVM contract reverted with bytes 0x{:?}",
+                hex::encode(&revert_bytes)
+            );
+            log.push(EventKind::AuroraTransactionFailed {
+                near_hash: Some(tx_hash),
+                aurora_hash: None,
+                error: AuroraTransactionError::Revert {
+                    bytes: revert_bytes,
+                },
+            });
+            Err(anyhow::Error::msg(error_message))
+        }
+        other => {
+            let error_message = format!("Deploy Aurora EVM contract error: {:?}", other);
+            log.push(EventKind::AuroraTransactionFailed {
+                near_hash: Some(tx_hash),
+                aurora_hash: None,
+                error: AuroraTransactionError::from_status(other).unwrap(),
+            });
+            Err(anyhow::Error::msg(error_message))
+        }
+    }
+}

--- a/connector-cli/src/near_rpc_ext/client_like.rs
+++ b/connector-cli/src/near_rpc_ext/client_like.rs
@@ -1,0 +1,116 @@
+//! Module containing an abstraction over `near_jsonrpc_client::JsonRpcClient`.
+//! This is useful because it makes mocking RPC interactions in tests easier
+//! (we only need to provide an alternate implementation of this trait instead
+//! of spinning up a real RPC server).
+
+use async_trait::async_trait;
+use near_jsonrpc_client::{methods::RpcMethod, JsonRpcClient, MethodCallResult};
+
+/// An abstraction over `near_jsonrpc_client::JsonRpcClient`.
+/// See module level-documentation for details.
+#[async_trait]
+pub trait ClientLike: Send + Sync + 'static {
+    async fn do_call<M: RpcMethod + Send>(
+        &self,
+        method: M,
+    ) -> MethodCallResult<M::Response, M::Error>;
+}
+
+#[async_trait]
+impl ClientLike for JsonRpcClient {
+    async fn do_call<M: RpcMethod + Send>(
+        &self,
+        method: M,
+    ) -> MethodCallResult<M::Response, M::Error> {
+        self.call(method).await
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use near_jsonrpc_client::methods::tx::TransactionInfo;
+    use near_primitives::{borsh::BorshDeserialize, transaction::SignedTransaction};
+
+    use super::*;
+
+    #[derive(Debug)]
+    pub enum AllMethods {
+        Query(near_jsonrpc_client::methods::query::RpcQueryRequest),
+        BroadcastTxAsync(
+            near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest,
+        ),
+        TxStatus(near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest),
+    }
+
+    pub struct MockClient<F> {
+        dispatch: F,
+    }
+
+    impl<F> MockClient<F>
+    where
+        F: Fn(AllMethods) -> serde_json::Value,
+    {
+        pub fn new(dispatch: F) -> Self {
+            Self { dispatch }
+        }
+    }
+
+    #[async_trait]
+    impl<F> ClientLike for MockClient<F>
+    where
+        F: Fn(AllMethods) -> serde_json::Value + Send + Sync + 'static,
+    {
+        async fn do_call<M: RpcMethod + Send>(
+            &self,
+            method: M,
+        ) -> MethodCallResult<M::Response, M::Error> {
+            let name = method.method_name();
+            let params = method.params().unwrap();
+
+            let request = match name {
+                "query" => AllMethods::Query(serde_json::from_value(params).unwrap()),
+                "broadcast_tx_async" => {
+                    let tx_base64 = params
+                        .as_array()
+                        .unwrap()
+                        .first()
+                        .unwrap()
+                        .as_str()
+                        .unwrap();
+                    let signed_tx = SignedTransaction::try_from_slice(
+                        &near_primitives::serialize::from_base64(tx_base64).unwrap(),
+                    )
+                    .unwrap();
+                    AllMethods::BroadcastTxAsync(near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {signed_transaction: signed_tx})
+                }
+                "tx" => {
+                    let params_arr = params.as_array().unwrap();
+                    let transaction_info = if params_arr.len() == 1 {
+                        let tx_base64 = params_arr.first().unwrap().as_str().unwrap();
+                        let signed_tx = SignedTransaction::try_from_slice(
+                            &near_primitives::serialize::from_base64(tx_base64).unwrap(),
+                        )
+                        .unwrap();
+                        TransactionInfo::Transaction(signed_tx)
+                    } else {
+                        let hash = serde_json::from_value(params_arr[0].clone()).unwrap();
+                        let account_id = serde_json::from_value(params_arr[1].clone()).unwrap();
+                        TransactionInfo::TransactionId { hash, account_id }
+                    };
+                    AllMethods::TxStatus(
+                        near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest {
+                            transaction_info,
+                        },
+                    )
+                }
+                other => panic!("RPC method {} not mocked", other),
+            };
+            let response = (self.dispatch)(request);
+            M::parse_handler_response(response).unwrap().map_err(|e| {
+                near_jsonrpc_client::errors::JsonRpcError::ServerError(
+                    near_jsonrpc_client::errors::JsonRpcServerError::HandlerError(e),
+                )
+            })
+        }
+    }
+}

--- a/connector-cli/src/near_rpc_ext/mod.rs
+++ b/connector-cli/src/near_rpc_ext/mod.rs
@@ -1,0 +1,140 @@
+//! Extension to `near-jsonrpc-client` to allow parallel execution and stronger typing.
+
+use near_account_id::AccountId;
+use near_crypto::PublicKey;
+use near_jsonrpc_client::methods::{self, tx::TransactionInfo};
+use near_primitives::{
+    errors::TxExecutionError,
+    hash::CryptoHash,
+    transaction::SignedTransaction,
+    types::{BlockHeight, BlockReference},
+    views::{
+        AccessKeyView, ContractCodeView, FinalExecutionOutcomeView, FinalExecutionStatus,
+        QueryRequest,
+    },
+};
+use std::{marker::PhantomData, sync::Arc};
+use tokio::task::JoinHandle;
+
+pub mod client_like;
+pub mod type_munging;
+
+pub fn query_access_key(
+    account_id: AccountId,
+    public_key: PublicKey,
+) -> JsonRpcRequest<methods::query::RpcQueryRequest, JsonRpcQueryResponse<AccessKeyView>> {
+    JsonRpcRequest {
+        inner: methods::query::RpcQueryRequest {
+            block_reference: BlockReference::latest(),
+            request: QueryRequest::ViewAccessKey {
+                account_id,
+                public_key,
+            },
+        },
+        _phantom: Default::default(),
+    }
+}
+
+pub fn query_code(
+    account_id: AccountId,
+) -> JsonRpcRequest<methods::query::RpcQueryRequest, JsonRpcQueryResponse<ContractCodeView>> {
+    JsonRpcRequest {
+        inner: methods::query::RpcQueryRequest {
+            block_reference: BlockReference::latest(),
+            request: QueryRequest::ViewCode { account_id },
+        },
+        _phantom: Default::default(),
+    }
+}
+
+pub fn broadcast_tx_async(
+    signed_transaction: SignedTransaction,
+) -> JsonRpcRequest<methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest, CryptoHash> {
+    JsonRpcRequest {
+        inner: methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest { signed_transaction },
+        _phantom: Default::default(),
+    }
+}
+
+pub fn tx_status(
+    account_id: AccountId,
+    tx_hash: CryptoHash,
+) -> JsonRpcRequest<methods::tx::RpcTransactionStatusRequest, FinalExecutionOutcomeView> {
+    JsonRpcRequest {
+        inner: methods::tx::RpcTransactionStatusRequest {
+            transaction_info: TransactionInfo::TransactionId {
+                hash: tx_hash,
+                account_id,
+            },
+        },
+        _phantom: Default::default(),
+    }
+}
+
+pub async fn wait_tx_executed<C: client_like::ClientLike>(
+    account_id: AccountId,
+    tx_hash: CryptoHash,
+    client: &C,
+) -> anyhow::Result<Result<Vec<u8>, TxExecutionError>> {
+    let request = tx_status(account_id, tx_hash);
+    loop {
+        let outcome = client.do_call(&request.inner).await?;
+        match outcome.status {
+            FinalExecutionStatus::SuccessValue(bytes) => {
+                return Ok(Ok(bytes));
+            }
+            FinalExecutionStatus::Failure(err) => {
+                return Ok(Err(err));
+            }
+            FinalExecutionStatus::NotStarted | FinalExecutionStatus::Started => {
+                // Wait 1 block and then try again
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+/// Represents a request of type `R` to the JSON RPC, where the response is of type `T`.
+/// This type is meant to be constructed by the convenience functions above and used by
+/// calling `spawn` (defined below) to execute the request and obtain the response.
+pub struct JsonRpcRequest<R, T> {
+    inner: R,
+    _phantom: PhantomData<T>,
+}
+
+/// A wrapper around a JSON RPC query response of type `T`. The wrapper includes the
+/// block hash and block height the query was executed at.
+pub struct JsonRpcQueryResponse<T> {
+    pub data: T,
+    pub block_height: BlockHeight,
+    pub block_hash: CryptoHash,
+}
+
+impl<R, T> JsonRpcRequest<R, T>
+where
+    R: methods::RpcMethod + Send + 'static,
+    T: type_munging::CoerceFrom<R::Response> + Send + 'static,
+    R::Error: std::error::Error + Send + Sync,
+{
+    pub fn spawn<C: client_like::ClientLike>(
+        self,
+        client: Arc<C>,
+    ) -> JoinHandle<anyhow::Result<T>> {
+        tokio::task::spawn(async move {
+            let response = client.do_call(self.inner).await?;
+            T::coerce_from(response)
+        })
+    }
+}
+
+impl<R, T> JsonRpcRequest<R, T>
+where
+    R: methods::RpcMethod + Send + Sync,
+    T: type_munging::CoerceFrom<R::Response>,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    pub async fn execute<C: client_like::ClientLike>(&self, client: &C) -> anyhow::Result<T> {
+        let response = client.do_call(&self.inner).await?;
+        T::coerce_from(response)
+    }
+}

--- a/connector-cli/src/near_rpc_ext/mod.rs
+++ b/connector-cli/src/near_rpc_ext/mod.rs
@@ -16,8 +16,11 @@ use near_primitives::{
 use std::{marker::PhantomData, sync::Arc};
 use tokio::task::JoinHandle;
 
+pub mod aurora_engine_utils;
 pub mod client_like;
 pub mod type_munging;
+
+pub const MAX_NEAR_GAS: u64 = 300_000_000_000_000;
 
 pub fn query_access_key(
     account_id: AccountId,

--- a/connector-cli/src/near_rpc_ext/type_munging.rs
+++ b/connector-cli/src/near_rpc_ext/type_munging.rs
@@ -1,0 +1,67 @@
+//! This module contains a convenience trait for mapping JSON RPC query response types to
+//! more useful ones. For example, all `RpcQueryRequest` inputs return the same `RpcQueryResponse`
+//! which has a `kind` field with an enum. Naturally, there is a correspondence between the kind
+//! of request and the kind of response, but the interface provided by `near_jsonrpc_client` does
+//! not reflect this, leading to unnecessary matches in code. To avoid this, the trait in this
+//! module allows automatically mapping `RpcQueryResponse` types to the real value they contain.
+//! This enables the strongly-types interface exposed in the parent module.
+
+use super::JsonRpcQueryResponse;
+use near_jsonrpc_client::methods;
+use near_jsonrpc_primitives::types::query::QueryResponseKind;
+use near_primitives::{
+    hash::CryptoHash,
+    views::{AccessKeyView, ContractCodeView},
+};
+
+pub trait CoerceFrom<R>: private::Sealed
+where
+    Self: Sized,
+{
+    fn coerce_from(response: R) -> anyhow::Result<Self>;
+}
+
+impl CoerceFrom<methods::query::RpcQueryResponse> for JsonRpcQueryResponse<AccessKeyView> {
+    fn coerce_from(response: methods::query::RpcQueryResponse) -> anyhow::Result<Self> {
+        let data = match response.kind {
+            QueryResponseKind::AccessKey(info) => Ok(info),
+            _ => Err(anyhow::Error::msg("Unexpected QueryResponseKind")),
+        }?;
+        Ok(JsonRpcQueryResponse {
+            data,
+            block_height: response.block_height,
+            block_hash: response.block_hash,
+        })
+    }
+}
+
+impl CoerceFrom<methods::query::RpcQueryResponse> for JsonRpcQueryResponse<ContractCodeView> {
+    fn coerce_from(response: methods::query::RpcQueryResponse) -> anyhow::Result<Self> {
+        let data = match response.kind {
+            QueryResponseKind::ViewCode(code_view) => Ok(code_view),
+            _ => Err(anyhow::Error::msg("Unexpected QueryResponseKind")),
+        }?;
+        Ok(JsonRpcQueryResponse {
+            data,
+            block_height: response.block_height,
+            block_hash: response.block_hash,
+        })
+    }
+}
+
+impl CoerceFrom<methods::broadcast_tx_async::RpcBroadcastTxAsyncResponse> for CryptoHash {
+    fn coerce_from(
+        response: methods::broadcast_tx_async::RpcBroadcastTxAsyncResponse,
+    ) -> anyhow::Result<Self> {
+        Ok(response)
+    }
+}
+
+mod private {
+    use super::*;
+    pub trait Sealed {}
+    impl Sealed for AccessKeyView {}
+    impl Sealed for ContractCodeView {}
+    impl Sealed for CryptoHash {}
+    impl<T: Sealed> Sealed for JsonRpcQueryResponse<T> {}
+}

--- a/connector-cli/src/tests/create_token.rs
+++ b/connector-cli/src/tests/create_token.rs
@@ -1,0 +1,110 @@
+use crate::{
+    config::Config,
+    log::{EventKind, Log},
+    near_rpc_ext::client_like::mock::{AllMethods, MockClient},
+    tests::{default_transaction, default_transaction_outcome},
+};
+use aurora_engine::parameters::{SubmitResult, TransactionStatus};
+use aurora_engine_types::types::Address;
+use borsh::BorshSerialize;
+use near_account_id::AccountId;
+use near_primitives::hash::CryptoHash;
+
+#[tokio::test]
+async fn test_create_token() {
+    let config = {
+        let mut tmp = Config::testnet();
+        // Pretend the locker is deployed already
+        tmp.locker_address = Some(near_token_common::Address(
+            hex::decode("c02079e49b8b2dc5b302d37d6c8beea26504dcd5")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        ));
+        tmp
+    };
+    let sk = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+    let key = near_crypto::KeyFile {
+        account_id: config.factory_account_id.clone(),
+        public_key: sk.public_key(),
+        secret_key: sk,
+    };
+
+    let aurora_account_id = config.aurora_account_id.clone();
+    let client = MockClient::new(move |method| rpc_handler(method, &aurora_account_id));
+
+    let mut log = Log::default();
+
+    let token_address = Address::decode("ed48f70ae9da554129680abade12c53d4d3ed51e").unwrap();
+    crate::create_token::create_token(
+        token_address,
+        &config,
+        std::sync::Arc::new(client),
+        &key,
+        &mut log,
+    )
+    .await
+    .unwrap();
+
+    // We submit the `create_token` transaction
+    assert!(matches!(
+        log.events.first().map(|e| &e.kind),
+        Some(EventKind::NearTransactionSubmitted { .. }),
+    ));
+    // And it is successful
+    assert!(matches!(
+        log.events.get(1).map(|e| &e.kind),
+        Some(EventKind::AuroraTransactionSuccessful { .. }),
+    ));
+}
+
+fn rpc_handler(method: AllMethods, aurora_account_id: &AccountId) -> serde_json::Value {
+    match method {
+        AllMethods::Query(query) => {
+            let response = match query.request {
+                near_primitives::views::QueryRequest::ViewAccessKey { .. } => {
+                    near_jsonrpc_client::methods::query::RpcQueryResponse {
+                        kind: near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(
+                            near_primitives::views::AccessKeyView {
+                                nonce: 0,
+                                permission:
+                                    near_primitives::views::AccessKeyPermissionView::FullAccess,
+                            },
+                        ),
+                        block_height: 0,
+                        block_hash: Default::default(),
+                    }
+                }
+                other => panic!("Unexpected query: {:?}", other),
+            };
+            serde_json::to_value(response).unwrap()
+        }
+        AllMethods::BroadcastTxAsync(tx) => {
+            let rx = &tx.signed_transaction.transaction.receiver_id;
+            if rx != aurora_account_id {
+                panic!("Unexpected transaction to {:?}", rx)
+            }
+            match tx.signed_transaction.transaction.actions.first() {
+                Some(near_primitives::transaction::Action::FunctionCall(f)) => {
+                    assert_eq!(f.method_name.as_str(), "call");
+                }
+                other => panic!("Unexpected transaction action {:?}", other),
+            }
+            let response = CryptoHash::default();
+            serde_json::to_value(response).unwrap()
+        }
+        AllMethods::TxStatus(_request) => {
+            let response = near_primitives::views::FinalExecutionOutcomeView {
+                status: near_primitives::views::FinalExecutionStatus::SuccessValue(
+                    SubmitResult::new(TransactionStatus::Succeed(Vec::new()), 0, Vec::new())
+                        .try_to_vec()
+                        .unwrap(),
+                ),
+                transaction: default_transaction(),
+                transaction_outcome: default_transaction_outcome(),
+                receipts_outcome: Vec::new(),
+            };
+            serde_json::to_value(response).unwrap()
+        }
+    }
+}

--- a/connector-cli/src/tests/deploy.rs
+++ b/connector-cli/src/tests/deploy.rs
@@ -1,14 +1,17 @@
 use crate::{
     config::Config,
-    log::{EventKind, Log, NearTransactionKind},
+    log::{AuroraTransactionKind, EventKind, Log, NearTransactionKind},
     near_rpc_ext::client_like::mock::{AllMethods, MockClient},
 };
+use aurora_engine::parameters::{SubmitResult, TransactionStatus};
+use aurora_engine_types::types::Address;
+use borsh::BorshSerialize;
 use near_account_id::AccountId;
 use near_primitives::{hash::CryptoHash, views};
 
 #[tokio::test]
 async fn test_deploy() {
-    let config = {
+    let mut config = {
         let mut tmp = Config::testnet();
         // Allow changed files in the repo (makes test pass during development)
         tmp.allow_changed_files = true;
@@ -24,16 +27,33 @@ async fn test_deploy() {
     let params = MockClientParameters {
         block_height: 7,
         block_hash: near_primitives::hash::hash(b"the_block"),
+        aurora_account_id: config.aurora_account_id.clone(),
         factory_account_id: config.factory_account_id.clone(),
+        codec_lib_address: Address::decode("ab86c24a63b1c364e422f0214dafbc77cb5351ec").unwrap(),
+        utils_lib_address: Address::decode("2cd3c85b8d055521e48655cb19ca684e9b88abc4").unwrap(),
+        sdk_lib_address: Address::decode("71f31b756c9af6b61174c2411ec1f44021728e05").unwrap(),
+        locker_address: Address::decode("41896a6ed87affe5f5059e03466723f7acc0d128").unwrap(),
         factory_code_hash: near_primitives::hash::hash(b"factory_code"),
         deploy_factory_tx_hash: near_primitives::hash::hash(b"deploy_factory_tx"),
+        deploy_codec_tx_hash: near_primitives::hash::hash(b"deploy_codec_tx"),
+        deploy_utils_tx_hash: near_primitives::hash::hash(b"deploy_utils_tx"),
+        deploy_sdk_tx_hash: near_primitives::hash::hash(b"deploy_sdk_tx"),
+        deploy_locker_tx_hash: near_primitives::hash::hash(b"deploy_locker_tx"),
+        factory_init_tx_hash: near_primitives::hash::hash(b"factory_init_tx"),
+        factory_set_token_tx_hash: near_primitives::hash::hash(b"factory_set_token_binary_tx"),
     };
     let client = default_client(params.clone());
     let mut log = Log::default();
 
-    crate::deploy::deploy(&config, std::sync::Arc::new(client), &key, &mut log)
+    crate::deploy::deploy(&mut config, std::sync::Arc::new(client), &key, &mut log)
         .await
         .unwrap();
+
+    // Locker address should be updated in the config after `deploy`
+    assert_eq!(
+        config.locker_address,
+        Some(near_token_common::Address(params.locker_address.raw().0)),
+    );
 
     // Check the logs contain the expected events:
     // First we make `near-token-factory` and `aurora-locker` (in either order)
@@ -78,15 +98,158 @@ async fn test_deploy() {
             }
         })
     );
+    // Then we submit the deploy codec transaction
+    assert_eq!(
+        log.events.get(5).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.deploy_codec_tx_hash
+        })
+    );
+    // And it was successful
+    assert_eq!(
+        log.events.get(6).map(|e| &e.kind),
+        Some(&EventKind::AuroraTransactionSuccessful {
+            near_hash: Some(params.deploy_codec_tx_hash),
+            aurora_hash: None,
+            kind: AuroraTransactionKind::DeployContract {
+                address: params.codec_lib_address,
+            }
+        })
+    );
+    // Then we submit the deploy utils transaction
+    assert_eq!(
+        log.events.get(7).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.deploy_utils_tx_hash
+        })
+    );
+    // And it was successful
+    assert_eq!(
+        log.events.get(8).map(|e| &e.kind),
+        Some(&EventKind::AuroraTransactionSuccessful {
+            near_hash: Some(params.deploy_utils_tx_hash),
+            aurora_hash: None,
+            kind: AuroraTransactionKind::DeployContract {
+                address: params.utils_lib_address,
+            }
+        })
+    );
+    // Then we build the aurora_sdk with the deployed libs
+    assert_eq!(
+        log.events.get(9).map(|e| &e.kind),
+        Some(&EventKind::Make {
+            command: format!(
+                "CODEC=0x{} UTILS=0x{} aurora-locker-sdk",
+                params.codec_lib_address.encode(),
+                params.utils_lib_address.encode()
+            )
+        })
+    );
+    // Then we submit the deploy aurora_sdk transaction
+    assert_eq!(
+        log.events.get(10).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.deploy_sdk_tx_hash
+        })
+    );
+    // And it was successful
+    assert_eq!(
+        log.events.get(11).map(|e| &e.kind),
+        Some(&EventKind::AuroraTransactionSuccessful {
+            near_hash: Some(params.deploy_sdk_tx_hash),
+            aurora_hash: None,
+            kind: AuroraTransactionKind::DeployContract {
+                address: params.sdk_lib_address,
+            }
+        })
+    );
+    // Then we build the locker with the deployed libs
+    assert_eq!(
+        log.events.get(12).map(|e| &e.kind),
+        Some(&EventKind::Make {
+            command: format!(
+                "CODEC=0x{} SDK=0x{} aurora-locker-with-libs",
+                params.codec_lib_address.encode(),
+                params.sdk_lib_address.encode()
+            )
+        })
+    );
+    // Then we submit the deploy locker transaction
+    assert_eq!(
+        log.events.get(13).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.deploy_locker_tx_hash
+        })
+    );
+    // And it was successful
+    assert_eq!(
+        log.events.get(14).map(|e| &e.kind),
+        Some(&EventKind::AuroraTransactionSuccessful {
+            near_hash: Some(params.deploy_locker_tx_hash),
+            aurora_hash: None,
+            kind: AuroraTransactionKind::DeployContract {
+                address: params.locker_address,
+            }
+        })
+    );
+    // Then we modify the config file with the new locker address
+    assert_eq!(
+        log.events.get(15).map(|e| &e.kind),
+        Some(&EventKind::ModifyConfigLockerAddress {
+            old_value: None,
+            new_value: Some(near_token_common::Address(params.locker_address.raw().0))
+        })
+    );
+    // Then we submit the initialize factory transaction
+    assert_eq!(
+        log.events.get(16).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.factory_init_tx_hash
+        })
+    );
+    // And it was successful
+    matches!(
+        log.events.get(17).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSuccessful {
+            hash,
+            kind: NearTransactionKind::FunctionCall { .. }
+        }) if hash == params.factory_init_tx_hash
+    );
+    // Then we submit the factory set_token_binary transaction
+    assert_eq!(
+        log.events.get(18).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.factory_set_token_tx_hash
+        })
+    );
+    // And it was successful
+    matches!(
+        log.events.get(19).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSuccessful {
+            hash,
+            kind: NearTransactionKind::FunctionCall { .. }
+        }) if hash == params.factory_set_token_tx_hash
+    );
 }
 
 #[derive(Debug, Clone)]
 struct MockClientParameters {
     pub block_height: u64,
     pub block_hash: CryptoHash,
+    pub aurora_account_id: AccountId,
     pub factory_account_id: AccountId,
+    pub codec_lib_address: Address,
+    pub utils_lib_address: Address,
+    pub sdk_lib_address: Address,
+    pub locker_address: Address,
     pub factory_code_hash: CryptoHash,
     pub deploy_factory_tx_hash: CryptoHash,
+    pub deploy_codec_tx_hash: CryptoHash,
+    pub deploy_utils_tx_hash: CryptoHash,
+    pub deploy_sdk_tx_hash: CryptoHash,
+    pub deploy_locker_tx_hash: CryptoHash,
+    pub factory_init_tx_hash: CryptoHash,
+    pub factory_set_token_tx_hash: CryptoHash,
 }
 
 #[derive(Debug)]
@@ -168,37 +331,17 @@ impl MockClientState {
                 }
                 other => panic!("Unexpected request {:?} in state {:?}", other, state),
             },
-            MockClientStateMachine::AwaitDeployExecute => match method {
-                AllMethods::TxStatus(request) => {
-                    match request.transaction_info {
-                        near_jsonrpc_client::methods::tx::TransactionInfo::Transaction(_) => {
-                            panic!("Unexpected TransactionInfo query")
-                        }
-                        near_jsonrpc_client::methods::tx::TransactionInfo::TransactionId {
-                            hash,
-                            account_id,
-                        } => {
-                            if hash != params.deploy_factory_tx_hash {
-                                panic!("Unexpected query of tx {:?}", hash);
-                            }
-                            if account_id != params.factory_account_id {
-                                panic!("Unexpected query of tx to account {:?}", account_id);
-                            }
-                        }
-                    }
-                    let response = near_primitives::views::FinalExecutionOutcomeView {
-                        status: near_primitives::views::FinalExecutionStatus::SuccessValue(
-                            Vec::new(),
-                        ),
-                        transaction: default_transaction(),
-                        transaction_outcome: default_transaction_outcome(),
-                        receipts_outcome: Vec::new(),
-                    };
-                    *state = MockClientStateMachine::CheckCodeDeployed;
-                    serde_json::to_value(response).unwrap()
-                }
-                other => panic!("Unexpected request {:?} in state {:?}", other, state),
-            },
+            MockClientStateMachine::AwaitDeployExecute => {
+                let response = await_tx_handler(
+                    method,
+                    params.deploy_factory_tx_hash,
+                    &params.factory_account_id,
+                    Vec::new(),
+                    state,
+                );
+                *state = MockClientStateMachine::CheckCodeDeployed;
+                response
+            }
             MockClientStateMachine::CheckCodeDeployed => match method {
                 AllMethods::Query(query) => {
                     let response = match query.request {
@@ -219,15 +362,243 @@ impl MockClientState {
                         }
                         other => panic!("Unexpected query: {:?}", other),
                     };
-                    *state = MockClientStateMachine::Done;
+                    *state = MockClientStateMachine::DeployCodec;
                     serde_json::to_value(response).unwrap()
                 }
                 other => panic!("Unexpected request {:?} in state {:?}", other, state),
             },
+            MockClientStateMachine::DeployCodec => {
+                let response = aurora_deploy_handler(
+                    method,
+                    &params.aurora_account_id,
+                    params.deploy_codec_tx_hash,
+                    state,
+                );
+                *state = MockClientStateMachine::AwaitDeployCodec;
+                response
+            }
+            MockClientStateMachine::AwaitDeployCodec => {
+                let response = await_tx_handler(
+                    method,
+                    params.deploy_codec_tx_hash,
+                    &params.factory_account_id,
+                    submit_result_with_address(params.codec_lib_address)
+                        .try_to_vec()
+                        .unwrap(),
+                    state,
+                );
+                *state = MockClientStateMachine::DeployUtils;
+                response
+            }
+            MockClientStateMachine::DeployUtils => {
+                let response = aurora_deploy_handler(
+                    method,
+                    &params.aurora_account_id,
+                    params.deploy_utils_tx_hash,
+                    state,
+                );
+                *state = MockClientStateMachine::AwaitDeployUtils;
+                response
+            }
+            MockClientStateMachine::AwaitDeployUtils => {
+                let response = await_tx_handler(
+                    method,
+                    params.deploy_utils_tx_hash,
+                    &params.factory_account_id,
+                    submit_result_with_address(params.utils_lib_address)
+                        .try_to_vec()
+                        .unwrap(),
+                    state,
+                );
+                *state = MockClientStateMachine::DeployAuroraSdk;
+                response
+            }
+            MockClientStateMachine::DeployAuroraSdk => {
+                let response = aurora_deploy_handler(
+                    method,
+                    &params.aurora_account_id,
+                    params.deploy_sdk_tx_hash,
+                    state,
+                );
+                *state = MockClientStateMachine::AwaitDeployAuroraSdk;
+                response
+            }
+            MockClientStateMachine::AwaitDeployAuroraSdk => {
+                let response = await_tx_handler(
+                    method,
+                    params.deploy_sdk_tx_hash,
+                    &params.factory_account_id,
+                    submit_result_with_address(params.sdk_lib_address)
+                        .try_to_vec()
+                        .unwrap(),
+                    state,
+                );
+                *state = MockClientStateMachine::DeployLocker;
+                response
+            }
+            MockClientStateMachine::DeployLocker => {
+                let response = aurora_deploy_handler(
+                    method,
+                    &params.aurora_account_id,
+                    params.deploy_locker_tx_hash,
+                    state,
+                );
+                *state = MockClientStateMachine::AwaitDeployLocker;
+                response
+            }
+            MockClientStateMachine::AwaitDeployLocker => {
+                let response = await_tx_handler(
+                    method,
+                    params.deploy_locker_tx_hash,
+                    &params.factory_account_id,
+                    submit_result_with_address(params.locker_address)
+                        .try_to_vec()
+                        .unwrap(),
+                    state,
+                );
+                *state = MockClientStateMachine::InitializeFactory;
+                response
+            }
+            MockClientStateMachine::InitializeFactory => {
+                let response = match method {
+                    AllMethods::BroadcastTxAsync(tx) => {
+                        let rx = &tx.signed_transaction.transaction.receiver_id;
+                        if rx != &params.factory_account_id {
+                            panic!("Unexpected transaction to {:?}", rx)
+                        }
+                        match tx.signed_transaction.transaction.actions.first() {
+                            Some(near_primitives::transaction::Action::FunctionCall(f)) => {
+                                assert_eq!(f.method_name.as_str(), "new");
+                            }
+                            other => panic!("Unexpected transaction action {:?}", other),
+                        }
+                        let response = params.factory_init_tx_hash;
+                        serde_json::to_value(response).unwrap()
+                    }
+                    other => panic!("Unexpected request {:?} in state {:?}", other, state),
+                };
+                *state = MockClientStateMachine::AwaitInitializeFactory;
+                response
+            }
+            MockClientStateMachine::AwaitInitializeFactory => {
+                let response = await_tx_handler(
+                    method,
+                    params.factory_init_tx_hash,
+                    &params.factory_account_id,
+                    Vec::new(),
+                    state,
+                );
+                *state = MockClientStateMachine::SetTokenBinary;
+                response
+            }
+            MockClientStateMachine::SetTokenBinary => {
+                let response = match method {
+                    AllMethods::BroadcastTxAsync(tx) => {
+                        let rx = &tx.signed_transaction.transaction.receiver_id;
+                        if rx != &params.factory_account_id {
+                            panic!("Unexpected transaction to {:?}", rx)
+                        }
+                        match tx.signed_transaction.transaction.actions.first() {
+                            Some(near_primitives::transaction::Action::FunctionCall(f)) => {
+                                assert_eq!(f.method_name.as_str(), "set_token_binary");
+                            }
+                            other => panic!("Unexpected transaction action {:?}", other),
+                        }
+                        let response = params.factory_set_token_tx_hash;
+                        serde_json::to_value(response).unwrap()
+                    }
+                    other => panic!("Unexpected request {:?} in state {:?}", other, state),
+                };
+                *state = MockClientStateMachine::AwaitSetTokenBinary;
+                response
+            }
+            MockClientStateMachine::AwaitSetTokenBinary => {
+                let response = await_tx_handler(
+                    method,
+                    params.factory_set_token_tx_hash,
+                    &params.factory_account_id,
+                    Vec::new(),
+                    state,
+                );
+                *state = MockClientStateMachine::Done;
+                response
+            }
             MockClientStateMachine::Done => {
                 panic!("Unexpected RPC method in Done state {:?}", method);
             }
         }
+    }
+}
+
+fn submit_result_with_address(address: Address) -> SubmitResult {
+    SubmitResult::new(
+        TransactionStatus::Succeed(address.as_bytes().to_vec()),
+        0,
+        Vec::new(),
+    )
+}
+
+#[track_caller]
+fn aurora_deploy_handler(
+    method: AllMethods,
+    aurora_account_id: &AccountId,
+    return_value: CryptoHash,
+    state: &MockClientStateMachine,
+) -> serde_json::Value {
+    match method {
+        AllMethods::BroadcastTxAsync(tx) => {
+            let rx = &tx.signed_transaction.transaction.receiver_id;
+            if rx != aurora_account_id {
+                panic!("Unexpected transaction to {:?}", rx)
+            }
+            match tx.signed_transaction.transaction.actions.first() {
+                Some(near_primitives::transaction::Action::FunctionCall(f)) => {
+                    assert_eq!(f.method_name.as_str(), "deploy_code");
+                }
+                other => panic!("Unexpected transaction action {:?}", other),
+            }
+            let response = return_value;
+            serde_json::to_value(response).unwrap()
+        }
+        other => panic!("Unexpected request {:?} in state {:?}", other, state),
+    }
+}
+
+#[track_caller]
+fn await_tx_handler(
+    method: AllMethods,
+    expected_hash: CryptoHash,
+    expected_account_id: &AccountId,
+    return_value: Vec<u8>,
+    state: &MockClientStateMachine,
+) -> serde_json::Value {
+    match method {
+        AllMethods::TxStatus(request) => {
+            match request.transaction_info {
+                near_jsonrpc_client::methods::tx::TransactionInfo::Transaction(_) => {
+                    panic!("Unexpected TransactionInfo query")
+                }
+                near_jsonrpc_client::methods::tx::TransactionInfo::TransactionId {
+                    hash,
+                    account_id,
+                } => {
+                    if hash != expected_hash {
+                        panic!("Unexpected query of tx {:?}", hash);
+                    }
+                    if &account_id != expected_account_id {
+                        panic!("Unexpected query of tx to account {:?}", account_id);
+                    }
+                }
+            }
+            let response = near_primitives::views::FinalExecutionOutcomeView {
+                status: near_primitives::views::FinalExecutionStatus::SuccessValue(return_value),
+                transaction: default_transaction(),
+                transaction_outcome: default_transaction_outcome(),
+                receipts_outcome: Vec::new(),
+            };
+            serde_json::to_value(response).unwrap()
+        }
+        other => panic!("Unexpected request {:?} in state {:?}", other, state),
     }
 }
 
@@ -242,6 +613,30 @@ enum MockClientStateMachine {
     AwaitDeployExecute,
     /// 4. check the factory account code hash again
     CheckCodeDeployed,
+    /// 5. deploy codec library to Aurora
+    DeployCodec,
+    /// 6. send tx status check to see if deploy is done
+    AwaitDeployCodec,
+    /// 7. deploy utils library to Aurora
+    DeployUtils,
+    /// 8. send tx status check to see if deploy is done
+    AwaitDeployUtils,
+    /// 9. deploy Aurora SDK library to Aurora
+    DeployAuroraSdk,
+    /// 10. send tx status check to see if deploy is done
+    AwaitDeployAuroraSdk,
+    /// 11. deploy Locker contract to Aurora
+    DeployLocker,
+    /// 12. send tx status check to see if deploy is done
+    AwaitDeployLocker,
+    /// 13. call `new` function in Factory
+    InitializeFactory,
+    /// 14. send tx status check to see if call is done
+    AwaitInitializeFactory,
+    /// 15. call `set_token_binary` function in Factory
+    SetTokenBinary,
+    /// 16. send tx status check to see if call is done
+    AwaitSetTokenBinary,
     /// Nothing else to do
     Done,
 }

--- a/connector-cli/src/tests/deploy.rs
+++ b/connector-cli/src/tests/deploy.rs
@@ -1,0 +1,299 @@
+use crate::{
+    config::Config,
+    log::{EventKind, Log, NearTransactionKind},
+    near_rpc_ext::client_like::mock::{AllMethods, MockClient},
+};
+use near_account_id::AccountId;
+use near_primitives::{hash::CryptoHash, views};
+
+#[tokio::test]
+async fn test_deploy() {
+    let config = {
+        let mut tmp = Config::testnet();
+        // Allow changed files in the repo (makes test pass during development)
+        tmp.allow_changed_files = true;
+        tmp.repository_root = Some("..".into());
+        tmp
+    };
+    let sk = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+    let key = near_crypto::KeyFile {
+        account_id: config.factory_account_id.clone(),
+        public_key: sk.public_key(),
+        secret_key: sk,
+    };
+    let params = MockClientParameters {
+        block_height: 7,
+        block_hash: near_primitives::hash::hash(b"the_block"),
+        factory_account_id: config.factory_account_id.clone(),
+        factory_code_hash: near_primitives::hash::hash(b"factory_code"),
+        deploy_factory_tx_hash: near_primitives::hash::hash(b"deploy_factory_tx"),
+    };
+    let client = default_client(params.clone());
+    let mut log = Log::default();
+
+    crate::deploy::deploy(&config, std::sync::Arc::new(client), &key, &mut log)
+        .await
+        .unwrap();
+
+    // Check the logs contain the expected events:
+    // First we make `near-token-factory` and `aurora-locker` (in either order)
+    match log.events.get(0).map(|e| &e.kind) {
+        Some(EventKind::Make { command }) if command.as_str() == "near-token-factory" => {
+            match log.events.get(1).map(|e| &e.kind) {
+                Some(EventKind::Make { command }) if command.as_str() == "aurora-locker" => (),
+                other => panic!("Unexpected log: {:?}", other),
+            }
+        }
+        Some(EventKind::Make { command }) if command.as_str() == "aurora-locker" => {
+            match log.events.get(1).map(|e| &e.kind) {
+                Some(EventKind::Make { command }) if command.as_str() == "near-token-factory" => (),
+                other => panic!("Unexpected log: {:?}", other),
+            }
+        }
+        other => panic!("Unexpected log: {:?}", other),
+    }
+    // Then we make the `near-token-contract`
+    assert_eq!(
+        log.events.get(2).map(|e| &e.kind),
+        Some(&EventKind::Make {
+            command: "near-token-contract".into()
+        })
+    );
+    // Then we submit the deploy transaction
+    assert_eq!(
+        log.events.get(3).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSubmitted {
+            hash: params.deploy_factory_tx_hash
+        })
+    );
+    // And the deploy was successful
+    assert_eq!(
+        log.events.get(4).map(|e| &e.kind),
+        Some(&EventKind::NearTransactionSuccessful {
+            hash: params.deploy_factory_tx_hash,
+            kind: NearTransactionKind::DeployCode {
+                account_id: params.factory_account_id,
+                new_code_hash: params.factory_code_hash,
+                previous_code_hash: None
+            }
+        })
+    );
+}
+
+#[derive(Debug, Clone)]
+struct MockClientParameters {
+    pub block_height: u64,
+    pub block_hash: CryptoHash,
+    pub factory_account_id: AccountId,
+    pub factory_code_hash: CryptoHash,
+    pub deploy_factory_tx_hash: CryptoHash,
+}
+
+#[derive(Debug)]
+struct MockClientState {
+    params: MockClientParameters,
+    state_machine: std::sync::Mutex<MockClientStateMachine>,
+}
+
+impl MockClientState {
+    fn process_client_method(&self, method: AllMethods) -> serde_json::Value {
+        use std::ops::DerefMut;
+
+        let params = &self.params;
+        let mut state_guard = self.state_machine.lock().unwrap();
+        let state = state_guard.deref_mut();
+        match state {
+            MockClientStateMachine::FactoryAccountSanity {
+                code_check,
+                key_check,
+            } => match method {
+                AllMethods::Query(query) => {
+                    let response = match query.request {
+                        near_primitives::views::QueryRequest::ViewCode { account_id } => {
+                            if account_id != params.factory_account_id {
+                                panic!("Unexpected ViewCode query to {:?}", account_id);
+                            }
+                            *code_check = true;
+                            near_jsonrpc_client::methods::query::RpcQueryResponse {
+                                    kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewCode(
+                                        near_primitives::views::ContractCodeView {
+                                            code: Vec::new(),
+                                            hash: Default::default(),
+                                        },
+                                    ),
+                                    block_height: params.block_height,
+                                    block_hash: params.block_hash,
+                                }
+                        }
+                        near_primitives::views::QueryRequest::ViewAccessKey {
+                            account_id, ..
+                        } => {
+                            if account_id != params.factory_account_id {
+                                panic!("Unexpected ViewAccessKey query to {:?}", account_id);
+                            }
+                            *key_check = true;
+                            near_jsonrpc_client::methods::query::RpcQueryResponse {
+                                    kind: near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(
+                                        near_primitives::views::AccessKeyView {
+                                            nonce: 0,
+                                            permission: near_primitives::views::AccessKeyPermissionView::FullAccess,
+                                        },
+                                    ),
+                                    block_height: params.block_height,
+                                    block_hash: params.block_hash,
+                                }
+                        }
+                        other => panic!("Unexpected query: {:?}", other),
+                    };
+                    if *code_check && *key_check {
+                        *state = MockClientStateMachine::DeployFactoryCode;
+                    }
+                    serde_json::to_value(response).unwrap()
+                }
+                other => panic!("Unexpected request {:?} in state {:?}", other, state),
+            },
+            MockClientStateMachine::DeployFactoryCode => match method {
+                AllMethods::BroadcastTxAsync(tx) => {
+                    let rx = &tx.signed_transaction.transaction.receiver_id;
+                    if rx != &params.factory_account_id {
+                        panic!("Unexpected transaction to {:?}", rx)
+                    }
+                    match tx.signed_transaction.transaction.actions.first() {
+                        Some(near_primitives::transaction::Action::DeployContract(_)) => (),
+                        other => panic!("Unexpected transaction action {:?}", other),
+                    }
+                    let response = params.deploy_factory_tx_hash;
+                    *state = MockClientStateMachine::AwaitDeployExecute;
+                    serde_json::to_value(response).unwrap()
+                }
+                other => panic!("Unexpected request {:?} in state {:?}", other, state),
+            },
+            MockClientStateMachine::AwaitDeployExecute => match method {
+                AllMethods::TxStatus(request) => {
+                    match request.transaction_info {
+                        near_jsonrpc_client::methods::tx::TransactionInfo::Transaction(_) => {
+                            panic!("Unexpected TransactionInfo query")
+                        }
+                        near_jsonrpc_client::methods::tx::TransactionInfo::TransactionId {
+                            hash,
+                            account_id,
+                        } => {
+                            if hash != params.deploy_factory_tx_hash {
+                                panic!("Unexpected query of tx {:?}", hash);
+                            }
+                            if account_id != params.factory_account_id {
+                                panic!("Unexpected query of tx to account {:?}", account_id);
+                            }
+                        }
+                    }
+                    let response = near_primitives::views::FinalExecutionOutcomeView {
+                        status: near_primitives::views::FinalExecutionStatus::SuccessValue(
+                            Vec::new(),
+                        ),
+                        transaction: default_transaction(),
+                        transaction_outcome: default_transaction_outcome(),
+                        receipts_outcome: Vec::new(),
+                    };
+                    *state = MockClientStateMachine::CheckCodeDeployed;
+                    serde_json::to_value(response).unwrap()
+                }
+                other => panic!("Unexpected request {:?} in state {:?}", other, state),
+            },
+            MockClientStateMachine::CheckCodeDeployed => match method {
+                AllMethods::Query(query) => {
+                    let response = match query.request {
+                        near_primitives::views::QueryRequest::ViewCode { account_id } => {
+                            if account_id != params.factory_account_id {
+                                panic!("Unexpected ViewCode query to {:?}", account_id);
+                            }
+                            near_jsonrpc_client::methods::query::RpcQueryResponse {
+                                    kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewCode(
+                                        near_primitives::views::ContractCodeView {
+                                            code: b"factory_code".to_vec(),
+                                            hash: params.factory_code_hash,
+                                        },
+                                    ),
+                                    block_height: params.block_height,
+                                    block_hash: params.block_hash,
+                                }
+                        }
+                        other => panic!("Unexpected query: {:?}", other),
+                    };
+                    *state = MockClientStateMachine::Done;
+                    serde_json::to_value(response).unwrap()
+                }
+                other => panic!("Unexpected request {:?} in state {:?}", other, state),
+            },
+            MockClientStateMachine::Done => {
+                panic!("Unexpected RPC method in Done state {:?}", method);
+            }
+        }
+    }
+}
+
+/// State machine describing how the Deploy flow should proceed
+#[derive(Debug)]
+enum MockClientStateMachine {
+    /// 1. check factory account has no code and we have an access key for it
+    FactoryAccountSanity { code_check: bool, key_check: bool },
+    /// 2. send deploy factory code transaction
+    DeployFactoryCode,
+    /// 3. send tx status check to see if deploy is done
+    AwaitDeployExecute,
+    /// 4. check the factory account code hash again
+    CheckCodeDeployed,
+    /// Nothing else to do
+    Done,
+}
+
+impl Default for MockClientStateMachine {
+    fn default() -> Self {
+        Self::FactoryAccountSanity {
+            code_check: false,
+            key_check: false,
+        }
+    }
+}
+
+fn default_client(
+    params: MockClientParameters,
+) -> MockClient<impl Fn(AllMethods) -> serde_json::Value + Send + Sync + 'static> {
+    let state = MockClientState {
+        params,
+        state_machine: std::sync::Mutex::new(MockClientStateMachine::default()),
+    };
+
+    MockClient::new(move |method: AllMethods| state.process_client_method(method))
+}
+
+fn default_transaction() -> views::SignedTransactionView {
+    views::SignedTransactionView {
+        signer_id: "signer.near".parse().unwrap(),
+        public_key: near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519),
+        nonce: 0,
+        receiver_id: "receiver.near".parse().unwrap(),
+        actions: Vec::new(),
+        signature: near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
+        hash: Default::default(),
+    }
+}
+
+fn default_transaction_outcome() -> views::ExecutionOutcomeWithIdView {
+    views::ExecutionOutcomeWithIdView {
+        proof: Vec::new(),
+        block_hash: Default::default(),
+        id: Default::default(),
+        outcome: views::ExecutionOutcomeView {
+            logs: Vec::new(),
+            receipt_ids: Vec::new(),
+            gas_burnt: 0,
+            tokens_burnt: 0,
+            executor_id: "executor.near".parse().unwrap(),
+            status: views::ExecutionStatusView::SuccessValue(Vec::new()),
+            metadata: views::ExecutionMetadataView {
+                version: 0,
+                gas_profile: None,
+            },
+        },
+    }
+}

--- a/connector-cli/src/tests/deploy.rs
+++ b/connector-cli/src/tests/deploy.rs
@@ -2,12 +2,13 @@ use crate::{
     config::Config,
     log::{AuroraTransactionKind, EventKind, Log, NearTransactionKind},
     near_rpc_ext::client_like::mock::{AllMethods, MockClient},
+    tests::{default_transaction, default_transaction_outcome},
 };
 use aurora_engine::parameters::{SubmitResult, TransactionStatus};
 use aurora_engine_types::types::Address;
 use borsh::BorshSerialize;
 use near_account_id::AccountId;
-use near_primitives::{hash::CryptoHash, views};
+use near_primitives::hash::CryptoHash;
 
 #[tokio::test]
 async fn test_deploy() {
@@ -223,13 +224,13 @@ async fn test_deploy() {
         })
     );
     // And it was successful
-    matches!(
+    assert!(matches!(
         log.events.get(19).map(|e| &e.kind),
         Some(&EventKind::NearTransactionSuccessful {
             hash,
             kind: NearTransactionKind::FunctionCall { .. }
         }) if hash == params.factory_set_token_tx_hash
-    );
+    ));
 }
 
 #[derive(Debug, Clone)]
@@ -659,36 +660,4 @@ fn default_client(
     };
 
     MockClient::new(move |method: AllMethods| state.process_client_method(method))
-}
-
-fn default_transaction() -> views::SignedTransactionView {
-    views::SignedTransactionView {
-        signer_id: "signer.near".parse().unwrap(),
-        public_key: near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519),
-        nonce: 0,
-        receiver_id: "receiver.near".parse().unwrap(),
-        actions: Vec::new(),
-        signature: near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
-        hash: Default::default(),
-    }
-}
-
-fn default_transaction_outcome() -> views::ExecutionOutcomeWithIdView {
-    views::ExecutionOutcomeWithIdView {
-        proof: Vec::new(),
-        block_hash: Default::default(),
-        id: Default::default(),
-        outcome: views::ExecutionOutcomeView {
-            logs: Vec::new(),
-            receipt_ids: Vec::new(),
-            gas_burnt: 0,
-            tokens_burnt: 0,
-            executor_id: "executor.near".parse().unwrap(),
-            status: views::ExecutionStatusView::SuccessValue(Vec::new()),
-            metadata: views::ExecutionMetadataView {
-                version: 0,
-                gas_profile: None,
-            },
-        },
-    }
 }

--- a/connector-cli/src/tests/mod.rs
+++ b/connector-cli/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod deploy;

--- a/connector-cli/src/tests/mod.rs
+++ b/connector-cli/src/tests/mod.rs
@@ -1,1 +1,36 @@
+use near_primitives::views;
+
+mod create_token;
 mod deploy;
+
+pub fn default_transaction() -> views::SignedTransactionView {
+    views::SignedTransactionView {
+        signer_id: "signer.near".parse().unwrap(),
+        public_key: near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519),
+        nonce: 0,
+        receiver_id: "receiver.near".parse().unwrap(),
+        actions: Vec::new(),
+        signature: near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
+        hash: Default::default(),
+    }
+}
+
+pub fn default_transaction_outcome() -> views::ExecutionOutcomeWithIdView {
+    views::ExecutionOutcomeWithIdView {
+        proof: Vec::new(),
+        block_hash: Default::default(),
+        id: Default::default(),
+        outcome: views::ExecutionOutcomeView {
+            logs: Vec::new(),
+            receipt_ids: Vec::new(),
+            gas_burnt: 0,
+            tokens_burnt: 0,
+            executor_id: "executor.near".parse().unwrap(),
+            status: views::ExecutionStatusView::SuccessValue(Vec::new()),
+            metadata: views::ExecutionMetadataView {
+                version: 0,
+                gas_profile: None,
+            },
+        },
+    }
+}

--- a/near-token-common/src/types.rs
+++ b/near-token-common/src/types.rs
@@ -33,7 +33,7 @@ impl From<CallArgs> for FunctionCallArgs {
 
 pub type WeiU256 = [u8; 32];
 
-#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq, Eq)]
 pub struct Address(#[serde(with = "address_serde_hex")] pub [u8; 20]);
 
 mod address_serde_hex {
@@ -51,7 +51,8 @@ mod address_serde_hex {
         D: Deserializer<'de>,
     {
         let s: String = Deserialize::deserialize(deserializer)?;
-        let bytes = hex::decode(s).map_err(Error::custom)?;
+        let no_prefix = s.strip_prefix("0x").unwrap_or(&s);
+        let bytes = hex::decode(no_prefix).map_err(Error::custom)?;
         bytes
             .try_into()
             .map_err(|_| Error::custom("Incorrect address length"))


### PR DESCRIPTION
A CLI with the ability to

- [x] Compile and deploy the contracts
- [ ] Upgrade the contracts
- [ ] List all tokens deployed by the factory

All events are logged (for accountability). The CLI accepts simple commands (e.g. `deploy`) without many flags/parameters on the command line; most configuration is contained in a config file.